### PR TITLE
refac(viz): collect waker and spawn events

### DIFF
--- a/rfr-subscriber/examples/ping-pong.rs
+++ b/rfr-subscriber/examples/ping-pong.rs
@@ -1,0 +1,63 @@
+use std::future::Future;
+
+use tokio::sync::mpsc;
+
+use rfr_subscriber::RfrLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let rfr_layer = RfrLayer::new();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let (up_tx, up_rx) = mpsc::channel::<()>(1);
+        let (dn_tx, dn_rx) = mpsc::channel::<()>(1);
+
+        let join_handles = vec![
+            spawn_named("ping", ping_pong(3, up_tx, dn_rx)),
+            spawn_named("pong", ping_pong(3, dn_tx.clone(), up_rx)),
+        ];
+
+        // serve
+        dn_tx.send(()).await.unwrap();
+
+        for jh in join_handles {
+            jh.await.unwrap();
+        }
+    });
+}
+
+async fn ping_pong(count: usize, tx: mpsc::Sender<()>, mut rx: mpsc::Receiver<()>) {
+    for _ in 0..count {
+        match rx.recv().await {
+            Some(_) => {
+                // received something!
+            }
+            None => break,
+        }
+
+        match tx.send(()).await {
+            Ok(_) => {
+                // sent something!
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[track_caller]
+fn spawn_named<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}

--- a/rfr-subscriber/examples/spawn.rs
+++ b/rfr-subscriber/examples/spawn.rs
@@ -15,9 +15,9 @@ fn main() {
     rt.block_on(async {
         let jh = spawn_named("outer", async {
             spawn_named("inner-awesome", async {
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                tokio::time::sleep(Duration::from_micros(50)).await;
             });
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_micros(100)).await;
         });
 
         _ = jh.await;

--- a/rfr-viz/reference/spawn.html
+++ b/rfr-viz/reference/spawn.html
@@ -65,7 +65,7 @@
             div.task-timeline {
                 float: left;
                 height: 20px;
-                /* 10px + 2 x 16px = 42px = height of task-details including padding */
+                /* 20px + 2 x 11px = 42px = height of task-details including padding */
                 padding-top: 11px; 
                 padding-bottom: 11px;
                 position: relative;
@@ -95,6 +95,12 @@
                 height: 16px;
                 width: 34px;
                 padding-top: 14px;
+
+                z-index: 5;
+            }
+
+            div.waker:hover, div.spawn:hover {
+                z-index: 10;
             }
 
             div.waker-line, div.spawn-line {
@@ -184,6 +190,30 @@
                 background-color: #30ba69;
             }
 
+            div.waker-border, div.spawn-border {
+                position: absolute;
+                width: 32px;
+                height: 15px;
+                border-width: 1px;
+                border-style: solid;
+            }
+
+            div.waker-border {
+                border-color: #b998d9;
+            }
+
+            div.spawn-border {
+                border-color: #30ba69;
+            }
+
+            div.waker:hover div.waker-border {
+                border-color: #9343dd;
+            }
+
+            div.spawn:hover div.spawn-border {
+                border-color: #09e364;
+            }
+
             div.waker-marker, div.waker-label, div.spawn-marker, div.spawn-label {
                 display: inline-block;
                 vertical-align: middle
@@ -224,8 +254,8 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 50px; width: 20px; max-width: 20px;"></div>
-                            <div class="spawn" style="left: 50px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
-                            <div class="waker" style="left: 56px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">D</div></div></div>
+                            <div class="spawn" style="left: 50px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="waker" style="left: 56px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">D</div></div></div>
                         </div>
                     </div>
                     <div class="task">
@@ -235,9 +265,9 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 350px; width: 200px; max-width: 200px;"></div><div class="task-state idle" style="width: 100px; max-width: 100px;"></div><div class="task-state scheduled" style="width: 30px; max-width: 30px;"></div><div class="task-state active" style="width: 120px; max-width: 120px;"></div>
-                            <div class="spawn" style="left: 350px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
-                            <div class="waker" style="left: 540px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">C</div></div></div>
-                            <div class="waker" style="left: 650px;"><div class="waker-line up" style="height: calc(20px + (42px * 1) - 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
+                            <div class="spawn" style="left: 350px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="waker" style="left: 540px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">C</div></div></div>
+                            <div class="waker" style="left: 650px;"><div class="waker-line up" style="height: calc(20px + (42px * 1) - 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
                         </div>
                     </div>
                     <div class="task">
@@ -247,9 +277,11 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 500px; width: 200px; max-width: 200px;"></div><div class="task-state idle" style="width: 100px; max-width: 100px;"></div><div class="task-state scheduled" style="width: 30px; max-width: 30px;"></div><div class="task-state active" style="width: 120px; max-width: 120px;"></div>
-                            <div class="spawn" style="left: 500px;"><div class="spawn-line down" style="height: calc(20px + (42px * 1) + 5px);"><div class="spawn-from"></div></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
-                            <div class="waker" style="left: 540px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">C</div></div></div>
-                            <div class="waker" style="left: 800px;"><div class="waker-line down" style="height: calc(20px + (42px * 1) + 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
+                            <div class="spawn" style="left: 500px;"><div class="spawn-line down" style="height: calc(20px + (42px * 1) + 5px);"><div class="spawn-from"></div></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="waker" style="left: 540px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">C</div></div></div>
+                            <div class="waker" style="left: 800px;"><div class="waker-line down" style="height: calc(20px + (42px * 1) + 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
+                            <div class="waker" style="left: 850px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">C</div></div></div>
+                            <div class="waker" style="left: 860px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">D</div></div></div>
                         </div>
                     </div>
                     <div class="task">
@@ -259,9 +291,9 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 900px; width: 100px; max-width: 100px;"></div><div class="task-state scheduled" style="width: 30px; max-width: 30px;"></div><div class="task-state active" style="width: 700px; max-width: 700px;"></div><div class="task-state scheduled" style="width: 30px; max-width: 30px;"></div><div class="task-state active" style="width: 600px; max-width: 600px;"></div>
-                            <div class="spawn" style="left: 900px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
-                            <div class="waker" style="left: 990px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">*W</div></div></div>
-                            <div class="waker" style="left: 1500px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">*W</div></div></div>
+                            <div class="spawn" style="left: 900px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="waker" style="left: 990px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">*W</div></div></div>
+                            <div class="waker" style="left: 1500px;"><div class="waker-line"></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">*W</div></div></div>
                         </div>
                     </div>
                 </div>
@@ -276,7 +308,7 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 150px; width: 40px; max-width: 40px;"></div>
-                            <div class="spawn" style="left: 150px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="spawn" style="left: 150px;"><div class="spawn-line"></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
                         </div>
                     </div>
                     <div class="task">
@@ -286,8 +318,8 @@
                         </div>
                         <div class="task-timeline">
                             <div class="task-state active" style="margin-left: 2000px; width: 200px; max-width: 200px;"></div><div class="task-state idle" style="width: 100px; max-width: 100px;"></div><div class="task-state scheduled" style="width: 30px; max-width: 30px;"></div><div class="task-state active" style="width: 120px; max-width: 120px;"></div>
-                            <div class="spawn" style="left: 2000px;"><div class="spawn-line down" style="height: calc(20px + (42px * 2) + (4px * 1) + 5px);"><div class="spawn-from"></div></div><div class="spawn-inner"><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
-                            <div class="waker" style="left: 2300px;"><div class="waker-line down" style="height: calc(20px + (42px * 2) + (4px * 1) + 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
+                            <div class="spawn" style="left: 2000px;"><div class="spawn-line down" style="height: calc(20px + (42px * 2) + (4px * 1) + 5px);"><div class="spawn-from"></div></div><div class="spawn-inner"><div class="spawn-border"></div><div class="spawn-marker"></div><div class="spawn-label">S</div></div></div>
+                            <div class="waker" style="left: 2300px;"><div class="waker-line down" style="height: calc(20px + (42px * 2) + (4px * 1) + 5px);"><div class="waker-from"></div></div><div class="waker-inner"><div class="waker-border"></div><div class="waker-marker"></div><div class="waker-label">W</div></div></div>
                         </div>
                     </div>
                 </div>

--- a/rfr-viz/src/collect.rs
+++ b/rfr-viz/src/collect.rs
@@ -1,0 +1,520 @@
+use std::{collections::HashMap, fmt, ops::Add, time::Duration};
+
+use rfr::rec::{self, WinTimestamp};
+
+pub(crate) struct WinTimeHandle {
+    start_time: rec::AbsTimestamp,
+}
+
+fn duration_from_abs_timestamp(abs_time: &rec::AbsTimestamp) -> Duration {
+    Duration::new(abs_time.secs, abs_time.subsec_micros * 1000)
+}
+
+impl WinTimeHandle {
+    pub(crate) fn new(recording_start_time: rec::AbsTimestamp) -> Self {
+        Self {
+            start_time: recording_start_time,
+        }
+    }
+
+    pub(crate) fn window_time(&self, abs_time: &rec::AbsTimestamp) -> rec::WinTimestamp {
+        let start_time = duration_from_abs_timestamp(&self.start_time);
+        let duration = Duration::new(abs_time.secs, abs_time.subsec_micros * 1000);
+        let window_micros = duration.saturating_sub(start_time).as_micros();
+        debug_assert!(window_micros < u64::MAX as u128, "recording time spans more than u64::MAX microseconds, which is more than 500 thousand years");
+
+        rec::WinTimestamp {
+            micros: window_micros as u64,
+        }
+    }
+}
+
+struct TaskTimeHandle {
+    start_time: rec::WinTimestamp,
+}
+
+impl TaskTimeHandle {
+    fn new(task_start_time: rec::WinTimestamp) -> Self {
+        Self {
+            start_time: task_start_time,
+        }
+    }
+
+    fn task_time(&self, win_time: &rec::WinTimestamp) -> TaskTimestamp {
+        TaskTimestamp {
+            micros: win_time.micros.saturating_sub(self.start_time.micros),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TaskTimestamp {
+    micros: u64,
+}
+
+impl TaskTimestamp {
+    fn saturating_sub(&self, other: &Self) -> u64 {
+        self.micros.saturating_sub(other.micros)
+    }
+
+    fn is_zero(&self) -> bool {
+        self.micros == 0
+    }
+}
+
+impl Add<TaskTimestamp> for rec::WinTimestamp {
+    type Output = Self;
+
+    fn add(self, rhs: TaskTimestamp) -> Self::Output {
+        WinTimestamp {
+            micros: self.micros + rhs.micros,
+        }
+    }
+}
+
+pub(crate) struct TaskEvents {
+    pub(crate) task: rec::Task,
+    pub(crate) events: Vec<rec::Record>,
+}
+
+impl TaskEvents {
+    fn new(task: rec::Task) -> Self {
+        Self {
+            task,
+            events: Vec::new(),
+        }
+    }
+}
+
+pub(crate) fn create_task_rows(records: Vec<rec::Record>) -> Vec<TaskRow> {
+    // Records is empty, we can skip everything else, there is nothing to do.
+    if records.is_empty() {
+        return Vec::new();
+    }
+
+    let first = records.first().expect("records is not empty");
+    let win_time_handle = WinTimeHandle::new(first.meta.timestamp.clone());
+
+    let tasks_events = collect_into_tasks(records);
+    collect_into_rows(win_time_handle, tasks_events)
+}
+
+pub(crate) fn collect_into_tasks(records: Vec<rec::Record>) -> Vec<TaskEvents> {
+    let mut tasks = HashMap::new();
+
+    for record in records {
+        if let rec::Event::Task(task) = record.event {
+            let task_entry = TaskEvents::new(task.clone());
+            tasks.insert(task.task_id, task_entry);
+        } else {
+            let task_id = match &record.event {
+                rec::Event::NewTask { id }
+                | rec::Event::TaskPollStart { id }
+                | rec::Event::TaskPollEnd { id }
+                | rec::Event::TaskDrop { id } => id,
+                rec::Event::WakerOp(rec::WakerAction { task_id, .. }) => task_id,
+                rec::Event::Task(_) => {
+                    unreachable!("task events have already been filtered out")
+                }
+            };
+            tasks.entry(*task_id).and_modify(|r| r.events.push(record));
+        }
+    }
+
+    tasks.into_values().collect()
+}
+
+pub(crate) struct TaskRow {
+    pub(crate) index: TaskIndex,
+    pub(crate) start_time: rec::WinTimestamp,
+    pub(crate) task: rec::Task,
+    pub(crate) sections: Vec<TaskSection>,
+    pub(crate) spawn: Option<SpawnEvent>,
+    pub(crate) wakings: Vec<WakeEvent>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TaskSection {
+    pub(crate) duration: u64,
+    pub(crate) state: TaskState,
+}
+
+#[derive(Debug)]
+pub(crate) enum TaskState {
+    Active,
+    Idle,
+    ActiveSchedueld,
+    IdleScheduled,
+}
+
+impl fmt::Display for TaskState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Active => "active",
+                Self::Idle => "idle",
+                Self::ActiveSchedueld => "active",
+                Self::IdleScheduled => "scheduled",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TaskEvent {
+    ts: TaskTimestamp,
+    kind: TaskEventKind,
+}
+
+#[derive(Debug, Clone)]
+enum TaskEventKind {
+    New,
+    PollStart,
+    PollEnd,
+    Drop,
+    Wake,
+}
+
+impl fmt::Display for TaskEventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::New => "new",
+                Self::PollStart => "poll start",
+                Self::PollEnd => "poll end",
+                Self::Drop => "drop",
+                Self::Wake => "wake",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct WakeEvent {
+    pub(crate) ts: TaskTimestamp,
+    pub(crate) kind: WakeEventKind,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum WakeEventKind {
+    Wake { by: Option<TaskIndex> },
+    WakeByRef { by: Option<TaskIndex> },
+    SelfWake,
+    SelfWakeByRef,
+    Clone,
+    Drop,
+}
+
+impl fmt::Display for WakeEventKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Wake { .. } => "W",
+                Self::WakeByRef { .. } => "*W",
+                Self::SelfWake => "sW",
+                Self::SelfWakeByRef => "*sW",
+                Self::Clone => "C",
+                Self::Drop => "D",
+            }
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct SpawnEvent {
+    pub(crate) ts: TaskTimestamp,
+    pub(crate) kind: SpawnEventKind,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum SpawnEventKind {
+    Spawn { by: Option<TaskIndex> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct TaskIndex {
+    index: usize,
+}
+
+impl TaskIndex {
+    pub(crate) fn new(index: usize) -> Self {
+        Self { index }
+    }
+
+    pub(crate) fn as_inner(&self) -> usize {
+        self.index
+    }
+}
+
+pub(crate) fn collect_into_rows(
+    win_time_handle: WinTimeHandle,
+    tasks_events: Vec<TaskEvents>,
+) -> Vec<TaskRow> {
+    let mut tasks_events = tasks_events;
+    tasks_events.sort_by_key(|t| t.task.task_id);
+
+    let tasks_with_indicies: Vec<_> = tasks_events
+        .into_iter()
+        .enumerate()
+        .map(|(idx, task_events)| (TaskIndex::new(idx), task_events))
+        .collect();
+    let task_indices: HashMap<_, _> = tasks_with_indicies
+        .iter()
+        .map(|(idx, task_events)| (task_events.task.task_id, *idx))
+        .collect();
+    let get_index =
+        |task_id: Option<rec::TaskId>| task_id.and_then(|id| task_indices.get(&id).copied());
+
+    let mut task_rows = Vec::new();
+    for (index, TaskEvents { task, events }) in tasks_with_indicies {
+        if events.is_empty() {
+            continue;
+        }
+
+        let first = &events.first().expect("events is not empty");
+        let start_time = if let rec::Event::NewTask { .. } = &first.event {
+            // The event starts within this window
+            win_time_handle.window_time(&first.meta.timestamp)
+        } else {
+            // The task started before this window, so we set the task time to start with
+            // the window.
+            rec::WinTimestamp::ZERO
+        };
+        let task_time_handle = TaskTimeHandle::new(start_time.clone());
+
+        let mut task_events = Vec::new();
+        let mut wake_events = Vec::new();
+        let mut spawn_event = None;
+        for rec in events {
+            use rec::Event::{NewTask, TaskDrop, TaskPollEnd, TaskPollStart, WakerOp};
+            let ts = task_time_handle.task_time(&win_time_handle.window_time(&rec.meta.timestamp));
+
+            match &rec.event {
+                NewTask { .. } => {
+                    debug_assert!(spawn_event.is_none(), "multiple NewTask events");
+                    spawn_event = Some(SpawnEvent {
+                        ts: ts.clone(),
+                        kind: SpawnEventKind::Spawn {
+                            by: get_index(task.context),
+                        },
+                    });
+                    task_events.push(TaskEvent {
+                        ts,
+                        kind: TaskEventKind::New,
+                    });
+                }
+                TaskPollStart { .. } => task_events.push(TaskEvent {
+                    ts,
+                    kind: TaskEventKind::PollStart,
+                }),
+                TaskPollEnd { .. } => task_events.push(TaskEvent {
+                    ts,
+                    kind: TaskEventKind::PollEnd,
+                }),
+                TaskDrop { .. } => task_events.push(TaskEvent {
+                    ts,
+                    kind: TaskEventKind::Drop,
+                }),
+                WakerOp(action) => {
+                    let kind = match &action.op {
+                        rec::WakerOp::Wake => {
+                            task_events.push(TaskEvent {
+                                ts: ts.clone(),
+                                kind: TaskEventKind::Wake,
+                            });
+
+                            if Some(action.task_id) == action.context {
+                                WakeEventKind::SelfWake
+                            } else {
+                                WakeEventKind::Wake {
+                                    by: get_index(action.context),
+                                }
+                            }
+                        }
+                        rec::WakerOp::WakeByRef => {
+                            task_events.push(TaskEvent {
+                                ts: ts.clone(),
+                                kind: TaskEventKind::Wake,
+                            });
+
+                            if Some(action.task_id) == action.context {
+                                WakeEventKind::SelfWakeByRef
+                            } else {
+                                WakeEventKind::WakeByRef {
+                                    by: get_index(action.context),
+                                }
+                            }
+                        }
+                        rec::WakerOp::Clone => WakeEventKind::Clone,
+                        rec::WakerOp::Drop => WakeEventKind::Drop,
+                    };
+                    wake_events.push(WakeEvent { ts, kind });
+                }
+                rec::Event::Task(_) => {
+                    unreachable!("the events vec shouldn't contain task objects")
+                }
+            }
+        }
+
+        println!("\n======== {task:?} ========");
+        println!("task_events: {task_events:?}");
+        println!("wake_events: {wake_events:?}");
+        println!("spawn_event: {spawn_event:?}");
+        println!("======== ======== ======== ========");
+
+        let mut task_sections = Vec::new();
+        if task_events.is_empty() {
+            continue;
+        }
+        let first = task_events.first().unwrap();
+
+        if !first.ts.is_zero() {
+            let extra_section_state = match &first.kind {
+                TaskEventKind::New => None,
+                TaskEventKind::PollStart => Some(TaskState::IdleScheduled),
+                TaskEventKind::PollEnd => Some(TaskState::Active),
+                TaskEventKind::Drop => Some(TaskState::Idle),
+                TaskEventKind::Wake => {
+                    if let Some(second) = task_events.get(1) {
+                        if let TaskEventKind::PollEnd = second.kind {
+                            Some(TaskState::Active)
+                        } else {
+                            Some(TaskState::Idle)
+                        }
+                    } else {
+                        Some(TaskState::Idle)
+                    }
+                }
+            };
+
+            if let Some(state) = extra_section_state {
+                task_sections.push(TaskSection {
+                    duration: first.ts.micros,
+                    state,
+                });
+            }
+        }
+
+        for curr_idx in 1..task_events.len() {
+            let current = &task_events[curr_idx];
+            let prev = &task_events[curr_idx - 1];
+            use TaskEventKind::{Drop, New, PollEnd, PollStart, Wake};
+
+            let section = match &current.kind {
+                New => Section::Invalid {
+                    from: prev.kind.clone(),
+                    to: current.kind.clone(),
+                },
+                PollStart => match &prev.kind {
+                    New | PollEnd => Section::New(TaskState::Idle),
+                    Wake => Section::New(TaskState::IdleScheduled),
+                    PollStart | Drop => Section::Invalid {
+                        from: prev.kind.clone(),
+                        to: current.kind.clone(),
+                    },
+                },
+                PollEnd => match &prev.kind {
+                    PollStart => Section::New(TaskState::Active),
+                    Wake => Section::New(TaskState::ActiveSchedueld),
+                    New | PollEnd | Drop => Section::Invalid {
+                        from: prev.kind.clone(),
+                        to: current.kind.clone(),
+                    },
+                },
+                Drop => match &prev.kind {
+                    New | PollEnd => Section::ReplaceWith {
+                        replace_last_n_sections: 2,
+                        new_state: TaskState::Idle,
+                    },
+                    Wake => Section::ReplaceWith {
+                        replace_last_n_sections: 2,
+                        new_state: TaskState::IdleScheduled,
+                    },
+                    PollStart | Drop => Section::Invalid {
+                        from: prev.kind.clone(),
+                        to: current.kind.clone(),
+                    },
+                },
+                Wake => match &prev.kind {
+                    New | PollEnd => Section::New(TaskState::Idle),
+                    PollStart => Section::New(TaskState::Active),
+                    Wake => Section::ExtendLast,
+                    Drop => Section::Invalid {
+                        from: prev.kind.clone(),
+                        to: current.kind.clone(),
+                    },
+                },
+            };
+
+            match section {
+                Section::New(state) => {
+                    task_sections.push(TaskSection {
+                        duration: current.ts.saturating_sub(&prev.ts),
+                        state,
+                    });
+                }
+                Section::ReplaceWith {
+                    replace_last_n_sections,
+                    new_state,
+                } => {
+                    // TODO(hds): should probably emit a warning if this would be less than 2.
+                    task_sections
+                        .truncate(task_sections.len().saturating_sub(replace_last_n_sections));
+                    task_sections.push(TaskSection {
+                        duration: current.ts.saturating_sub(&prev.ts),
+                        state: new_state,
+                    });
+                }
+                Section::ExtendLast => {
+                    if let Some(last) = task_sections.last_mut() {
+                        last.duration += current.ts.saturating_sub(&prev.ts);
+                    } else {
+                        // Report error (this state shouldn't occur)
+                    }
+                }
+                Section::Invalid { .. } => {
+                    // Report warning and then continue
+                }
+            }
+        }
+
+        println!("\n======== {task:?} ========");
+        println!("task_events: {task_events:?}");
+        println!("wake_events: {wake_events:?}");
+        println!("spawn_event: {spawn_event:?}");
+        println!("task_sections: {task_sections:?}");
+        println!("======== ======== ======== ========");
+
+        task_rows.push(TaskRow {
+            index,
+            start_time,
+            task,
+            spawn: spawn_event,
+            sections: task_sections,
+            wakings: wake_events,
+        });
+    }
+
+    task_rows
+}
+
+enum Section {
+    New(TaskState),
+    ReplaceWith {
+        replace_last_n_sections: usize,
+        new_state: TaskState,
+    },
+    ExtendLast,
+    Invalid {
+        #[allow(dead_code)]
+        from: TaskEventKind,
+        #[allow(dead_code)]
+        to: TaskEventKind,
+    },
+}

--- a/rfr-viz/src/section_rules.md
+++ b/rfr-viz/src/section_rules.md
@@ -1,0 +1,9 @@
+
+
+| Prev / Current | NewTask | TaskPollStart      | TaskPollEnd          | TaskDrop           | Wake                |
++----------------|---------|--------------------|----------------------|--------------------|---------------------|
+| NewTask        | Invalid | idle section       | Invalid              | idle section       | idle section        |
+| TaskPollStart  | Invalid | Invalid            | active section       | invalid            | active section      |
+| TaskPollEnd    | Invalid | idle section       | Invalid              | idle section       | idle section        |
+| TaskDrop       | Invalid | Invalid            | Invalid              | Invalid            | Invalid             |
+| Wake           | Invalid | idle-sched section | active-sched section | idle-sched section | Extend last section |


### PR DESCRIPTION
In the initial dummy implementation, only task events (excluding wakes)
were processed and visualized.

Visualizing wake and spawn events is somewhat more complicated, it is
made additionally so if we want to be more robush when collecting the
task events, and include waking actions in those task events.

This commit is the first step towards doing so.

We assign all the events for a given task to that task (thus removing
the fake `Task` event from the list). The remaining event records are
then converted into 3 different event types:
- TaskEvent: this includes new, drop, and poll start and end as well as
  wake and wake by ref events.
- WakeEvent: this includes wake, wake by ref, clone, and drop wake
  events. Additionally, the wake and wake by ref events are divided into
  normal and self-* events (so there are 6 kinds in total)
- SpawnEvent: this is the event where a task is spawned. A task can have
  0 or 1 of these.

The TaskEvents are then walked and a list of TaskSection elements are
created. These task sections can be used directly to construct the task
stte bar in the visualization. The WakeEvent objects and SpawnEvent
object can be used directly to visualize the waker markers and spawn
marker respectively.

This change also adds a hover style to the spawn and waker markers such
that they come in front of other markers (there is often overlap because
the markers are close together) and shows a border around the marker
with the same color as the line and arrows.