### PR TITLE
docs: add initial book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/docs/book

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Hayden Stainsby <hds@caffeineconcepts.com>"]
+language = "en"
+multilingual = false
+src = "src"
+title = "Rust Flight Recording Book"

--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -1,0 +1,4 @@
+# RFR
+
+A description of RFR (Rust Flight Recording), a collection of tools for recording application state
+during execution and analyzing and visualizing that state during execution or post mortem.

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,0 +1,12 @@
+# Summary
+
+[RFR](README.md)
+
+- [File Format](file-format.md)
+  - [Encoding](file-format/encoding.md)
+  - [Format identifier](file-format/format-identifier.md)
+  - [Common](file-format/common.md)
+  - [Streaming](file-format/streaming.md)
+  - [Chunked](file-format/chunked.md)
+
+[Glossary](glossary.md)

--- a/docs/src/file-format.md
+++ b/docs/src/file-format.md
@@ -1,0 +1,23 @@
+# File Format
+
+[RFR](glossary.md#rfr) defines formats for storing flight recordings based on different
+requirements.
+
+The [streaming](file-format/streaming.md) format is designed to minimise in-process resource
+consumption for single threaded applications. It can be implemented by a [Tracing] subscriber
+without the [`Registry`] or any additional state and could be adapted to run in `no_std` environments.
+It's primary downside is that a consumer must have the entire flight recording to interpret the
+contents. As such, it is not suitable for long running applications unless post-processing of the
+stream can be performed during execution.
+
+The [chunked](file-format/chunked.md) format is designed to balance in-process resource consumption
+for multi-threaded applications with reduced storage requirements and the possibility of reading
+only small sections of the flight recording at a time without having to have previously consumed all
+prior sections.
+
+Both formats have a common [header](file-format/header.md) and use the [Postcard] wire format for
+the [encoding](file-format/encoding.md).
+
+[Postcard]: https://postcard.jamesmunns.com/
+[`Registry`]: https://docs.rs/tracing-subscriber/0.3/tracing_subscriber/registry/struct.Registry.html
+[Tracing]: https://docs.rs/tracing

--- a/docs/src/file-format/chunked.md
+++ b/docs/src/file-format/chunked.md
@@ -1,0 +1,163 @@
+# Chunked
+
+The chunked format is designed to balance in-process resource consumption for multi-threaded
+applications with reduced storage requirements and the possibility of reading only small sections of
+the flight recording at a time without having to have previously consumed all prior sections.
+
+The chunked file format is not yet documented (or implemented).
+
+## Format identifier
+
+The chunked file format has the variant identifier `rfr-c`. This chapter describes the format for
+version `rfr-s/0.0.2`.
+
+For a description of the identifer encoding see the [Format identifier](format-identifier.md)
+chapter.
+
+## Recording Structure
+
+The RFR chunked format encodes information about a singe execution of an application in multiple
+files - "chunks". Each chunk represents a specific, non-overlapping time period during the
+application execution.
+
+The layout of the separate files on disk is the following:
+
+- dir: `<recording-name>.rfr/`
+  - file: `meta.rfr`
+  - dir: `<year>-<month>/<day>-<hour>/`
+    - file: `chunk-<seconds>.<sub-seconds>.rfr`
+
+The exact split of sub-directories is not overly important, it's there to help humans navigate the
+flight recording structure and to avoid placing too many files in a single directory, which is
+something that some file systems have problems with.
+
+The key take away is that we have a reserved `meta.rfr` file for flight recording wide configuration
+declaration. Aside from that we have chunk files which are self contained recording files for a
+short time period, on the order of 1 second.
+
+## Chunk Structure
+
+The chunk file encodes information about a short period of time during the execution of a single
+application. The structure tries to make the file as independent as possible, so that chunks can be
+read from the middle of an execution. The structure is the following:
+
+| Element            | Representation                       |
+|--------------------|--------------------------------------|
+| format\_identifier | [`string`] (see [Format Identifier]) |
+| base\_time         | [AbsTimestampSecs]                   |
+| start\_time        | [ChunkTimestamp]                     |
+| end\_time          | [ChunkTimestamp]                     |
+| thread\_chunks     | \[[ThreadChunk]\]                    |
+
+
+### AbsTimestampSecs
+
+An absolute timestamp measured as time since the UNIX epoch (`1970-01-01T00:00Z`). The time has
+seconds resolution and is encoded as a [`varint(u64)`].
+
+### ChunkTimestamp
+
+A chunk timestamp represents the time of an event with respect to the chunk's base time. It is
+stored as the number of microseconds since the base time. All events within a chunk must occur at
+the base time or afterwards.
+
+Chunk timestamps are encoded as a [`newtype_struct`] of a [`varint(u64)`]. This gives it a range of
+500 thousand years after the base time, which is more than enough.
+
+<div class="warning">
+NEEDS REVIEW:
+
+At microsecond precision, a `u32` would only provide 71 minutes of range, which may be enough,
+should we switch to storing a `u32` internally? These values are encoded as [`varint(u64)`] so there
+won't be any difference in the file format as long as we stay within the value range of a `u32`,
+just the internal memory representation.
+</div>
+
+### ThreadChunk
+
+All events are recorded thread local. After a chunk's time period has finished, all the thread local
+parts are collected and written out. The thread chunk contains the thread local recording.
+
+Thread chunks are not aggregated prior to being written out. As such, it is possible that the
+objects stored in one thread chunk may be duplicated in other thread chunks within the same parent chunk.
+
+| Element     | Representation    |
+|-------------|-------------------|
+| start\_time | [ChunkTimestamp]  |
+| end\_time   | [ChunkTimestamp]  |
+| objects     | \[[Object]\]      |
+| events      | \[[EventRecord]\] |
+
+The start time and end time are the minimum and maximum times of the recorded events in this thread
+chunk respectively.
+
+The objects array contains all objects referenced by events in this thread chunk. The events contain
+the occurences during the time period. This structure is different from the [streaming] file format
+where events and objects are mixed in a single stream of records.
+
+### Object
+An object is a [tagged union] that contains object data. Object data isn't expected to change
+significanly during the course of an application execution.
+
+At this time, the only objects are tasks.
+
+| Variant | Discriminant | Data   |
+|---------|--------------|--------|
+| Task    | 0            | [Task] |
+
+### EventRecord
+
+A record contains timing metadata and a single event.
+
+| Element | Representation  |
+|---------|-----------------|
+| meta    | [Meta]          |
+| event   | [Event](#Event) |
+
+
+### Meta
+
+Metadata for a record.
+
+| Element   | Representation   |
+|-----------|------------------|
+| timestamp | [ChunkTimestamp] |
+
+### Event
+
+Event is a [tagged union] that contains events concerning those objects.
+
+| Variant        | Discriminant | Data                        |
+|----------------|--------------|-----------------------------|
+| NewTask        | 0            | `id`: [TaskId]              |
+| TaskPollStart  | 1            | `id`: [TaskId]              |
+| TaskPollEnd    | 2            | `id`: [TaskId]              |
+| TaskDrop       | 3            | `id`: [TaskId]              |
+| WakerWake      | 4            | `waker`: [Waker]            |
+| WakerWakeByRef | 5            | `waker`: [Waker]            |
+| WakerClone     | 6            | `waker`: [Waker]            |
+| WakerDrop      | 7            | `waker`: [Waker]            |
+
+Events are encoded in a single large [tagged union] rather than hierachically as each level of a
+union hierarchy costs an extra byte (for unions with up to 127 variants).
+
+
+[Format Identifier]: #format-identifier
+
+[AbsTimestampSecs]: #abstimestampsecs
+[ChunkTimestamp]: #chunktimestamp
+[EventRecord]: #eventrecord
+[Meta]: #meta
+[Object]: #object
+[ThreadChunk]: #threadchunk
+
+[Task]: common.md#task
+[TaskId]: common.md#taskid
+[Waker]: common.md#waker
+[streaming]: streaming.md
+
+[tagged union]: https://postcard.jamesmunns.com/wire-format#tagged-unions
+[`option`]: https://postcard.jamesmunns.com/wire-format#17---option
+[`varint(u64)`]: https://postcard.jamesmunns.com/wire-format#10---u64
+[`string`]: https://postcard.jamesmunns.com/wire-format#15---string
+[`newtype_struct`]: https://postcard.jamesmunns.com/wire-format#21---newtype_struct

--- a/docs/src/file-format/common.md
+++ b/docs/src/file-format/common.md
@@ -1,0 +1,56 @@
+# Common
+
+A number of data structures are common between the [streaming](streaming.md) and
+[chunked](chunked.md) file formats.
+
+
+### Task
+
+| Element    | Representation         |
+|------------|------------------------|
+| task\_id   | [TaskId]               |
+| task\_name | [`string`]             |
+| task\_kind | [TaskKind](#taskkind)  |
+| context    | [`option`]\([TaskId]\) |
+
+
+### TaskId
+
+The task Id is the runtime defined identifier for a task stored as a [`newtype_struct`] of a single
+[`varint(u64)`].
+
+
+### TaskKind
+
+The kind of a task is stored as [tagged union], however only the `Other` variant has additional
+data.
+
+| Variant  | Discriminant | Data       |
+|----------|--------------|------------|
+| Task     | 0            |            |
+| Local    | 1            |            |
+| Blocking | 2            |            |
+| BlockOn  | 3            |            |
+| Other    | 4            | [`string`] |
+
+
+### Waker
+
+A waker action contains context information about the waker and where the action occurred.
+
+The task Id is that of the task that the waker will wake when invoked. The context describes where
+the waker action occurred, specifically when it occurred within a task.
+
+| Element    | Representation         |
+|------------|------------------------|
+| task\_id   | [TaskId]               |
+| context    | [`option`]\([TaskId]\) |
+
+
+[TaskId]: #taskid
+
+[tagged union]: https://postcard.jamesmunns.com/wire-format#tagged-unions
+[`option`]: https://postcard.jamesmunns.com/wire-format#17---option
+[`varint(u64)`]: https://postcard.jamesmunns.com/wire-format#10---u64
+[`string`]: https://postcard.jamesmunns.com/wire-format#15---string
+[`newtype_struct`]: https://postcard.jamesmunns.com/wire-format#21---newtype_struct

--- a/docs/src/file-format/encoding.md
+++ b/docs/src/file-format/encoding.md
@@ -1,0 +1,15 @@
+# Encoding
+
+The contents of flight recording files is encoded in the Postcard wire format.
+
+Postcard is a `#![no_std]` focused serializer and deserializer for [Serde].
+
+Postcard aims to be convenient for developers in constrained environments, while allowing for
+flexibility to customize behavior as needed.
+
+The wire format specification is hosted at [postcard.jamesmunns.com]. It is implemented by the
+[postcard crate].
+
+[postcard crate]: https://docs.rs/postcard/1.0/postcard/
+[postcard.jamesmunns.com]: https://postcard.jamesmunns.com/
+[Serde]: https://serde.rs/

--- a/docs/src/file-format/format-identifier.md
+++ b/docs/src/file-format/format-identifier.md
@@ -1,0 +1,37 @@
+# Format identifier
+
+The format identifier is the beginning of a file, whether the streaming or chunked file format is
+used. It declares the format variant and the version of that variant which is used.
+
+The variant and version are encoded as a single [`string`] with the following parts:
+
+- variant: 1 to 8 characters (all printable ASCII characters except `/`)
+- divider: literal `/` character
+- version: dot `.` separated version string containing decimal digit characters:
+  - major
+  - minor
+  - patch
+
+## Restrictions
+
+The complete format identifier should occupy no more than 24 characters in total.
+
+
+## Examples
+
+The header string `rfr-foo/1.0.2` would decompose as:
+- variant: `rfr-foo`
+- divider: `/`
+- version:
+  - major: `1`
+  - minor: `0`
+  - patch: `2`
+
+
+## Why is it stringly typed?
+
+The format identifier is encoded as a string instead of using enum variant integers for the variant
+and integers for the version parts. This is to allow easy human inspection of the file format at the
+cost of slightly more complex parsing.
+
+[`string`]: https://postcard.jamesmunns.com/wire-format#15---string

--- a/docs/src/file-format/streaming.md
+++ b/docs/src/file-format/streaming.md
@@ -1,0 +1,96 @@
+# Streaming
+
+The streaming format is designed to minimise in-process resource consumption for single threaded
+applications. It can be implemented without keeping any central state between async events.
+
+It can be implemented by a [Tracing] subscriber without the need for the [`tracing-subscriber`]
+crate. It could be adapted to run in `!#[no_std]` environments.
+
+It's primary downside is that a consumer must have the entire flight recording to interpret the
+contents. As such, it is not suitable for long running applications unless post-processing of the
+stream can be performed during execution.
+
+## Format identifier
+
+The streaming file format has the variant identifier `rfr-s`. This chapter describes the format for
+version `rfr-s/0.0.3`.
+
+For a description of the identifer encoding see the [Format identifier](format-identifier.md)
+chapter.
+
+## Structure
+
+The RFR streaming format encodes information about a single execution of an application in a single
+file. The structure is the following:
+
+| Element            | Representation                       |
+|--------------------|--------------------------------------|
+| format\_identifier | [`string`] (see [Format Identifier]) |
+| records            | [Record](#record) (repeats)          |
+| end record         | [Record](#record)                    |
+
+The records element is **not** a sequence (i.e. array or vector), but rather repeating elements.
+When reading, care must be taken to respect the end of the file or stream that the flight recording
+is being read from.
+
+When the instrumented application terminates, a token record should indicate that no more records
+will be written. This uses the `End` variant of the [Event](#event) stored in the final record.
+
+### Record
+
+A record contains timing metadata and a single event.
+
+| Element | Representation  |
+|---------|-----------------|
+| meta    | [Meta](#meta)   |
+| event   | [Event](#Event) |
+
+
+### Meta
+
+| Element   | Representation  |
+|-----------|-----------------|
+| timestamp | [AbsTimestamp]  |
+
+### AbsTimestamp
+
+An absolute timestamp measured as time since the UNIX epoch (`1970-01-01T00:00Z`). The time is
+stored as seconds and sub-seconds as microsecond precision.
+
+| Element        | Representation  |
+|----------------|-----------------|
+| secs           | [`varint(u64)`] |
+| subsec\_micros | [`varint(u32)`] |
+
+
+### Event
+
+Event is a [tagged union] that contains objects and events concerning those objects.
+
+| Variant        | Discriminant | Data                        |
+|----------------|--------------|-----------------------------|
+| Task           | 0            | [Task]                      |
+| NewTask        | 1            | `id`: [TaskId]              |
+| TaskPollStart  | 2            | `id`: [TaskId]              |
+| TaskPollEnd    | 3            | `id`: [TaskId]              |
+| TaskDrop       | 4            | `id`: [TaskId]              |
+| WakerWake      | 5            | `waker`: [Waker]            |
+| WakerWakeByRef | 6            | `waker`: [Waker]            |
+| WakerClone     | 7            | `waker`: [Waker]            |
+| WakerDrop      | 8            | `waker`: [Waker]            |
+| End            | 9            |                             |
+
+
+[AbsTimestamp]: #abstimestamp
+
+[Task]: common.md#task
+[TaskId]: common.md#taskid
+[Waker]: common.md#waker
+
+[tagged union]: https://postcard.jamesmunns.com/wire-format#tagged-unions
+[`varint(u32)`]: https://postcard.jamesmunns.com/wire-format#9---u32
+[`varint(u64)`]: https://postcard.jamesmunns.com/wire-format#10---u64
+[`option`]: https://postcard.jamesmunns.com/wire-format#17---option
+[`string`]: https://postcard.jamesmunns.com/wire-format#15---string
+[`unit_variant`]: https://postcard.jamesmunns.com/wire-format#20---unit_variant
+[`newtype_struct`]: https://postcard.jamesmunns.com/wire-format#21---newtype_struct

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -1,0 +1,5 @@
+# Glossary
+
+## rfr
+
+Rust Flight Recording is the name of this project. Pronounced _ruffer_.


### PR DESCRIPTION
The content of the book so far describes the purposes of RFR, as well as
file formats.

The encoding links to Postcard and the (new) format identifier is
defined.

A new version (`rfr-s/0.0.3`) of the streaming file format is defined.
It is only slightly different from the current format.

The anticipated chunked file format is also described. This has not yet
been implemented at all.

Those types which are shared between both file formats are listed in a
common sub-chapter.