### PR TITLE
feat(rfr,subscriber): add initial chunked implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "jiff"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab9be28ecf3427731981f9404337c3a126ee35d2a645f0aca92112367e3c1a6e"
+dependencies = [
+ "jiff-tzdb-platform",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05fac328b3df1c0f18a3c2ab6cb7e06e4e549f366017d796e3e66b6d6889abe6"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8da387d5feaf355954c2c122c194d6df9c57d865125a67984bb453db5336940"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,6 +429,7 @@ dependencies = [
 name = "rfr"
 version = "0.0.1"
 dependencies = [
+ "jiff",
  "postcard",
  "serde",
 ]

--- a/docs/src/file-format/chunked.md
+++ b/docs/src/file-format/chunked.md
@@ -25,7 +25,7 @@ The layout of the separate files on disk is the following:
 - dir: `<recording-name>.rfr/`
   - file: `meta.rfr`
   - dir: `<year>-<month>/<day>-<hour>/`
-    - file: `chunk-<seconds>.<sub-seconds>.rfr`
+    - file: `chunk-<minute>-<second>.rfr`
 
 The exact split of sub-directories is not overly important, it's there to help humans navigate the
 flight recording structure and to avoid placing too many files in a single directory, which is

--- a/rfr-subscriber/examples/spawn-chunked.rs
+++ b/rfr-subscriber/examples/spawn-chunked.rs
@@ -1,0 +1,40 @@
+use std::{future::Future, time::Duration};
+
+use rfr_subscriber::RfrChunkedLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let rfr_layer = RfrChunkedLayer::new("./chunked-spawn.rfr");
+    let flusher = rfr_layer.flusher();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let jh = spawn_named("outer", async {
+            spawn_named("inner-awesome", async {
+                tokio::time::sleep(Duration::from_micros(50)).await;
+            });
+            tokio::time::sleep(Duration::from_micros(100)).await;
+        });
+
+        _ = jh.await;
+    });
+
+    flusher.flush();
+}
+
+#[track_caller]
+fn spawn_named<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}

--- a/rfr-subscriber/src/lib.rs
+++ b/rfr-subscriber/src/lib.rs
@@ -1,3 +1,4 @@
 mod subscriber;
 
+pub use subscriber::RfrChunkedLayer;
 pub use subscriber::RfrLayer;

--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -1,0 +1,339 @@
+use std::{
+    cell::RefCell,
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    thread::{self, JoinHandle},
+};
+
+use tracing::{span, subscriber::Interest, Event, Metadata, Subscriber};
+use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+
+use rfr::{
+    chunked::{self, AbsTimestampSecs, ChunkedWriter},
+    rec,
+};
+
+use crate::subscriber::common::{
+    get_context_task_id, CallsiteId, EventKind, SpanKind, SpawnFields, SpawnSpan, TaskId, TaskKind,
+    TraceKind, WakerFields, WakerOp,
+};
+
+struct WriterHandle {
+    writer: Arc<ChunkedWriter>,
+    join_handle: Mutex<Option<JoinHandle<()>>>,
+}
+
+pub struct Flusher {
+    writer: Arc<ChunkedWriter>,
+}
+
+impl Flusher {
+    pub fn flush(&self) {
+        self.writer.write();
+    }
+}
+
+pub struct RfrChunkedLayer {
+    writer_handle: WriterHandle,
+    callsite_cache: Mutex<HashMap<CallsiteId, TraceKind>>,
+    object_cache: Mutex<HashMap<rec::TaskId, chunked::Object>>,
+}
+
+impl RfrChunkedLayer {
+    pub fn new(base_dir: &str) -> Self {
+        let writer_handle = Self::spawn_writer(base_dir.to_owned());
+
+        Self {
+            writer_handle,
+            callsite_cache: Default::default(),
+            object_cache: Default::default(),
+        }
+    }
+
+    fn spawn_writer(base_dir: String) -> WriterHandle {
+        let writer = Arc::new(ChunkedWriter::new(base_dir.to_owned()));
+
+        let thread_writer = Arc::clone(&writer);
+        let join_handle = thread::Builder::new()
+            .name("rfr-writer".to_owned())
+            .spawn(move || run_writer_loop(thread_writer))
+            .unwrap();
+
+        WriterHandle {
+            writer,
+            join_handle: Mutex::new(Some(join_handle)),
+        }
+    }
+
+    pub fn flusher(&self) -> Flusher {
+        Flusher {
+            writer: Arc::clone(&self.writer_handle.writer),
+        }
+    }
+
+    pub fn complete(&self) {
+        let join_handle = {
+            let mut guard = self.writer_handle.join_handle.lock().expect("poisoned");
+            guard.take()
+        };
+        if let Some(join_handle) = join_handle {
+            // TODO(hds): signal writer thread to stop
+            join_handle.join().unwrap();
+
+            self.writer_handle.writer.write();
+        } else {
+            // Otherwise some other thread has joined on the writer.
+        }
+    }
+
+    fn new_object(&self, task_id: rec::TaskId, object: chunked::Object) {
+        let mut object_cache = self.object_cache.lock().expect("object cache poisoned");
+        object_cache.insert(task_id, object);
+    }
+
+    fn drop_object(&self, task_id: &rec::TaskId) {
+        let mut object_cache = self.object_cache.lock().expect("object cache poisoned");
+        object_cache.remove(task_id);
+    }
+
+    fn get_objects(&self, task_ids: &[rec::TaskId]) -> Vec<Option<chunked::Object>> {
+        let object_cache = self.object_cache.lock().expect("object cache poisoned");
+        task_ids
+            .iter()
+            .map(|task_id| object_cache.get(task_id).cloned())
+            .collect()
+    }
+
+    fn write_record(&self, timestamp: rec::AbsTimestamp, event: chunked::Event) {
+        thread_local! {
+            pub static CHUNK_BUFFER: RefCell<Option<Arc<chunked::ThreadChunkBuffer>>>
+                = const { RefCell::new(None) };
+        }
+
+        CHUNK_BUFFER.with_borrow_mut(|chunk_buffer| {
+            let current_buffer = self.current_chunk_buffer(chunk_buffer, timestamp.clone());
+            let record = chunked::EventRecord {
+                meta: chunked::Meta {
+                    timestamp: current_buffer.chunk_timestamp(timestamp),
+                },
+                event,
+            };
+            current_buffer.append_record(record, |task_ids| self.get_objects(task_ids));
+        });
+    }
+
+    fn current_chunk_buffer<'a>(
+        &self,
+        local_buffer: &'a mut Option<Arc<chunked::ThreadChunkBuffer>>,
+        timestamp: rec::AbsTimestamp,
+    ) -> &'a mut Arc<chunked::ThreadChunkBuffer> {
+        let base_time = AbsTimestampSecs::from(timestamp.clone());
+        let buffer = local_buffer.get_or_insert_with(|| self.new_chunk(timestamp.clone()));
+
+        match base_time.cmp(&buffer.base_time()) {
+            std::cmp::Ordering::Equal => {
+                // Stored chunk is the current one, do nothing
+            }
+            std::cmp::Ordering::Greater => {
+                // Stored chunk is old, we need a new one
+                *buffer = self.new_chunk(timestamp.clone());
+            }
+            std::cmp::Ordering::Less => {
+                // Stored chunk is from the future? This is invalid!
+                panic!(
+                    "Current base time is {base_time:?}, but stored base time is \
+                    {buffer_base_time:?}, which is from the future!",
+                    buffer_base_time = buffer.base_time()
+                );
+            }
+        }
+
+        buffer
+    }
+
+    fn new_chunk(&self, timestamp: rec::AbsTimestamp) -> Arc<chunked::ThreadChunkBuffer> {
+        let new_chunk = Arc::new(chunked::ThreadChunkBuffer::new(timestamp));
+        self.writer_handle
+            .writer
+            .register_chunk(Arc::clone(&new_chunk));
+
+        new_chunk
+    }
+}
+
+fn run_writer_loop(writer: Arc<ChunkedWriter>) {
+    _ = writer;
+}
+
+impl<S> Layer<S> for RfrChunkedLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn register_callsite(&self, metadata: &'static Metadata<'static>) -> Interest {
+        match TraceKind::try_from(metadata) {
+            Ok(kind) => {
+                let callsite = CallsiteId::from(metadata);
+                let mut callsite_cache = self
+                    .callsite_cache
+                    .lock()
+                    .expect("callsite cache is poisoned");
+                callsite_cache.entry(callsite).or_insert(kind);
+
+                Interest::always()
+            }
+            Err(_) => Interest::never(),
+        }
+    }
+
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+        let rec_meta = rec::Meta::now();
+        let callsite = CallsiteId::from(attrs.metadata());
+        let kind = {
+            let callsite_cache = self.callsite_cache.lock().expect("callsite cache poisoned");
+            let Some(kind) = callsite_cache.get(&callsite).cloned() else {
+                return;
+            };
+            kind
+        };
+        match kind {
+            TraceKind::Span(SpanKind::Spawn) => {
+                let mut fields = SpawnFields::default();
+                attrs.record(&mut fields);
+                if !fields.is_valid() {
+                    return;
+                }
+                let context = get_context_task_id(&ctx);
+
+                let spawn = SpawnSpan::new(callsite, id.clone(), context, fields);
+
+                let span = ctx
+                    .span(id)
+                    .expect("new_span {id:?} not found, this is a bug");
+                let mut extensions = span.extensions_mut();
+                if extensions.get_mut::<TaskId>().is_none() {
+                    extensions.insert(spawn.task_id);
+                }
+                {
+                    let task_id = rec::TaskId::from(spawn.task_id.0);
+                    let task_event = chunked::Object::Task(rec::Task {
+                        task_id,
+                        task_name: spawn.task_name,
+                        task_kind: match spawn.task_kind {
+                            TaskKind::Task => rec::TaskKind::Task,
+                            TaskKind::Local => rec::TaskKind::Local,
+                            TaskKind::Blocking => rec::TaskKind::Blocking,
+                            TaskKind::BlockOn => rec::TaskKind::BlockOn,
+                            TaskKind::Other(val) => rec::TaskKind::Other(val),
+                        },
+
+                        context: spawn.context.map(|task_id| rec::TaskId::from(task_id.0)),
+                    });
+                    self.new_object(task_id, task_event);
+                    let new_event = chunked::Event::NewTask { id: task_id };
+                    self.write_record(rec_meta.timestamp, new_event);
+                }
+            }
+            _ => {
+                // Not yet implemented
+            }
+        }
+    }
+
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        let rec_meta = rec::Meta::now();
+        let callsite = CallsiteId::from(event.metadata());
+        let kind = {
+            let callsite_cache = self.callsite_cache.lock().expect("callsite cache poisoned");
+            let Some(kind) = callsite_cache.get(&callsite).cloned() else {
+                return;
+            };
+            kind
+        };
+        match kind {
+            TraceKind::Event(EventKind::Waker) => {
+                let mut fields = WakerFields::default();
+                event.record(&mut fields);
+                if !fields.is_valid() {
+                    return;
+                }
+                let op = fields.op.unwrap();
+                let task_span_id = fields.task_span_id.unwrap();
+                let Some(task_id) = ctx
+                    .span(&task_span_id)
+                    .and_then(|span| span.extensions().get::<TaskId>().cloned())
+                else {
+                    // We can't find the task id for the task we're supposed to be waking.
+                    return;
+                };
+                let context = get_context_task_id(&ctx);
+
+                //let waker = WakerEvent::new(op, task_id, context, callsite);
+                {
+                    let waker = chunked::Waker {
+                        task_id: rec::TaskId::from(task_id.0),
+                        context: context.map(|task_id| rec::TaskId::from(task_id.0)),
+                    };
+                    let waker_event = match op {
+                        WakerOp::Wake => chunked::Event::WakerWake { waker },
+                        WakerOp::WakeByRef => chunked::Event::WakerWakeByRef { waker },
+                        WakerOp::Clone => chunked::Event::WakerClone { waker },
+                        WakerOp::Drop => chunked::Event::WakerDrop { waker },
+                    };
+
+                    self.write_record(rec_meta.timestamp, waker_event);
+                }
+            }
+            _ => {
+                // Not yet implemented
+            }
+        }
+    }
+
+    fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let rec_meta = rec::Meta::now();
+        let span = ctx.span(id).expect("enter {id:?} not found, this is a bug");
+        let extensions = span.extensions();
+        if let Some(task_id) = extensions.get::<TaskId>() {
+            // This is a runtime.spawn span
+            {
+                let task_id = rec::TaskId::from(task_id.0);
+                let poll_start = chunked::Event::TaskPollStart { id: task_id };
+
+                self.write_record(rec_meta.timestamp, poll_start);
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &span::Id, ctx: Context<'_, S>) {
+        let rec_meta = rec::Meta::now();
+        let span = ctx.span(id).expect("exit {id:?} not found, this is a bug");
+        let extensions = span.extensions();
+        if let Some(task_id) = extensions.get::<TaskId>() {
+            // This is a runtime.spawn span
+            {
+                let task_id = rec::TaskId::from(task_id.0);
+                let poll_end = chunked::Event::TaskPollEnd { id: task_id };
+
+                self.write_record(rec_meta.timestamp, poll_end);
+            }
+        }
+    }
+
+    fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
+        let rec_meta = rec::Meta::now();
+        let span = ctx
+            .span(&id)
+            .expect("close {id:?} not found, this is a bug");
+        let extensions = span.extensions();
+        if let Some(task_id) = extensions.get::<TaskId>() {
+            // This is a runtime.spawn span
+            {
+                let task_id = rec::TaskId::from(task_id.0);
+                let task_drop = chunked::Event::TaskDrop { id: task_id };
+
+                self.write_record(rec_meta.timestamp, task_drop);
+                self.drop_object(&task_id);
+            }
+        }
+    }
+}

--- a/rfr-subscriber/src/subscriber/mod.rs
+++ b/rfr-subscriber/src/subscriber/mod.rs
@@ -1,4 +1,6 @@
+mod chunked;
 mod common;
 mod layer;
 
+pub use chunked::RfrChunkedLayer;
 pub use layer::RfrLayer;

--- a/rfr/Cargo.toml
+++ b/rfr/Cargo.toml
@@ -13,5 +13,6 @@ keywords = ["tracing", "debugging"]
 
 
 [dependencies]
+jiff = "0.1"
 postcard = { version = "1.0.8", features = ["alloc", "use-std"] }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/rfr/src/chunked.rs
+++ b/rfr/src/chunked.rs
@@ -1,0 +1,359 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs, io,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
+
+use jiff::{tz::TimeZone, Timestamp, Zoned};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    rec::{self, AbsTimestamp, Task, TaskId},
+    FormatIdentifier, FormatVariant,
+};
+
+fn current_software_version() -> FormatIdentifier {
+    FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 0,
+        minor: 0,
+        patch: 2,
+    }
+}
+
+#[derive(Debug)]
+pub struct ChunkedWriter {
+    root_dir: String,
+    base_time: AbsTimestampSecs,
+
+    chunks: Mutex<Vec<Arc<ThreadChunkBuffer>>>,
+}
+
+impl ChunkedWriter {
+    pub fn new(root_dir: String) -> Self {
+        let timestamp = rec::AbsTimestamp::now();
+        let base_time = AbsTimestampSecs::from(timestamp.clone());
+        let header = MetaHeader {
+            created_time: timestamp,
+            base_time,
+        };
+        fs::create_dir_all(&root_dir).unwrap();
+        Self::write_meta(&root_dir, &header);
+
+        let writer = Self {
+            root_dir,
+            base_time,
+            chunks: Mutex::new(Vec::new()),
+        };
+
+        let base_time = writer.base_time;
+        writer.ensure_dir(&base_time);
+
+        writer
+    }
+
+    fn write_meta(base_dir: &String, header: &MetaHeader) -> bool {
+        let path = Path::new(base_dir).join("meta.rfr");
+        {
+            let mut file = fs::File::create(path).unwrap();
+
+            let version = format!("{}", current_software_version());
+            postcard::to_io(&version, &mut file).unwrap();
+
+            postcard::to_io(header, &mut file).unwrap();
+        }
+
+        true
+    }
+
+    fn ensure_dir(&self, time: &AbsTimestampSecs) {
+        fs::create_dir_all(self.dir_path(time)).unwrap();
+    }
+
+    fn dir_path(&self, time: &AbsTimestampSecs) -> PathBuf {
+        let ts = Timestamp::from_second(time.secs as i64).unwrap();
+        let ts_utc = ts.to_zoned(TimeZone::UTC);
+        self.dir_path_from_utc(&ts_utc)
+    }
+
+    fn dir_path_from_utc(&self, ts_utc: &Zoned) -> PathBuf {
+        Path::new(&self.root_dir)
+            .join(format!("{}", ts_utc.strftime("%Y-%m")))
+            .join(format!("{}", ts_utc.strftime("%d-%H")))
+    }
+
+    fn chunk_path(&self, time: &AbsTimestampSecs) -> PathBuf {
+        let ts = Timestamp::from_second(time.secs as i64).unwrap();
+        let ts_utc = ts.to_zoned(TimeZone::UTC);
+
+        self.dir_path_from_utc(&ts_utc)
+            .join(format!("chunk-{}.rfr", ts_utc.strftime("%M-%S")))
+    }
+
+    pub fn register_chunk(&self, chunk: Arc<ThreadChunkBuffer>) {
+        let mut chunks = self.chunks.lock().expect("poisoned");
+
+        chunks.push(chunk);
+    }
+
+    pub fn write(&self) {
+        let mut chunk_buffers: HashMap<AbsTimestampSecs, ChunkBuffer> = HashMap::new();
+        let mut thread_chunks = self.chunks.lock().expect("poisoned");
+
+        for thread_chunk in &*thread_chunks {
+            chunk_buffers
+                .entry(thread_chunk.base_time)
+                .and_modify(|chunk| chunk.push_thread_chunk(Arc::clone(thread_chunk)))
+                .or_insert_with(|| ChunkBuffer::with_first_thread_chunk(Arc::clone(thread_chunk)));
+        }
+
+        for chunk_buffer in chunk_buffers.into_values() {
+            let writer = self.writer_for_chunk(&chunk_buffer);
+            chunk_buffer.write(writer);
+        }
+
+        thread_chunks.clear();
+    }
+
+    fn writer_for_chunk(&self, chunk: &ChunkBuffer) -> impl io::Write {
+        fs::File::create(self.chunk_path(&chunk.base_time)).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub struct ChunkBuffer {
+    base_time: AbsTimestampSecs,
+    start_time: AbsTimestamp,
+    end_time: AbsTimestamp,
+
+    thread_chunks: Vec<Arc<ThreadChunkBuffer>>,
+}
+
+impl ChunkBuffer {
+    fn with_first_thread_chunk(thread_chunk: Arc<ThreadChunkBuffer>) -> Self {
+        Self {
+            base_time: thread_chunk.base_time,
+            start_time: thread_chunk.start_time.clone(),
+            end_time: thread_chunk.end_time.clone(),
+            thread_chunks: vec![thread_chunk],
+        }
+    }
+
+    fn push_thread_chunk(&mut self, thread_chunk: Arc<ThreadChunkBuffer>) {
+        assert_eq!(self.base_time, thread_chunk.base_time);
+
+        self.start_time = self.start_time.clone().min(thread_chunk.start_time.clone());
+        self.end_time = self.end_time.clone().max(thread_chunk.end_time.clone());
+
+        self.thread_chunks.push(thread_chunk);
+    }
+
+    fn write(&self, writer: impl io::Write) {
+        let mut writer = writer;
+
+        let version = format!("{}", current_software_version());
+        postcard::to_io(&version, &mut writer).unwrap();
+
+        postcard::to_io(&self.base_time, &mut writer).unwrap();
+        postcard::to_io(&self.start_time, &mut writer).unwrap();
+        postcard::to_io(&self.end_time, &mut writer).unwrap();
+
+        postcard::to_io(&self.thread_chunks.len(), &mut writer).unwrap();
+        for thread_chunk in &self.thread_chunks {
+            thread_chunk.write(&mut writer);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ThreadChunkBuffer {
+    base_time: AbsTimestampSecs,
+    start_time: AbsTimestamp,
+    end_time: AbsTimestamp,
+    buffer: Mutex<Buffer>,
+}
+
+#[derive(Debug, Default)]
+struct Buffer {
+    objects: HashMap<TaskId, Vec<u8>>,
+    missing_objects: HashSet<TaskId>,
+    event_count: usize,
+    events: Vec<u8>,
+}
+
+impl ThreadChunkBuffer {
+    pub fn new(now: AbsTimestamp) -> Self {
+        Self {
+            base_time: now.clone().into(),
+            start_time: now.clone(),
+            end_time: now,
+            buffer: Default::default(),
+        }
+    }
+
+    pub fn base_time(&self) -> AbsTimestampSecs {
+        self.base_time
+    }
+
+    pub fn chunk_timestamp(&self, timestamp: rec::AbsTimestamp) -> ChunkTimestamp {
+        let secs = timestamp.secs.saturating_sub(self.base_time.secs);
+        let micros = (secs * 1_000_000) + timestamp.subsec_micros as u64;
+        ChunkTimestamp::new(micros)
+    }
+
+    pub fn append_record<F>(&self, record: EventRecord, get_objects: F)
+    where
+        F: FnOnce(&[TaskId]) -> Vec<Option<Object>>,
+    {
+        let mut buffer = self.buffer.lock().expect("poisoned");
+        let mut missing_task_ids = Vec::new();
+        match &record.event {
+            Event::NewTask { id }
+            | Event::TaskPollStart { id }
+            | Event::TaskPollEnd { id }
+            | Event::TaskDrop { id } => {
+                if !buffer.objects.contains_key(id) {
+                    missing_task_ids.push(*id);
+                }
+            }
+            Event::WakerWake { waker }
+            | Event::WakerWakeByRef { waker }
+            | Event::WakerClone { waker }
+            | Event::WakerDrop { waker } => {
+                if !buffer.objects.contains_key(&waker.task_id) {
+                    missing_task_ids.push(waker.task_id);
+                }
+                if let Some(context_task_id) = &waker.context {
+                    if context_task_id != &waker.task_id
+                        && !buffer.objects.contains_key(context_task_id)
+                    {
+                        missing_task_ids.push(*context_task_id);
+                    }
+                }
+            }
+        }
+
+        let missing_tasks = get_objects(missing_task_ids.as_slice());
+        for (task_id, task) in missing_task_ids.into_iter().zip(missing_tasks.into_iter()) {
+            match task {
+                Some(task) => {
+                    let task_buffer = postcard::to_stdvec(&task).unwrap();
+                    buffer.objects.insert(task_id, task_buffer);
+                }
+                None => {
+                    // TODO(hds): Currently we don't do anything with this information, should we?
+                    //            Also, should we actually return early here or should we continue?
+                    //            If we do want to return early, we should probably not write any
+                    //            task data to `buffer.objects`.
+                    buffer.missing_objects.insert(task_id);
+                    return;
+                }
+            }
+        }
+
+        postcard::to_io(&record, &mut buffer.events).unwrap();
+        buffer.event_count += 1;
+    }
+
+    fn write(&self, writer: impl io::Write) {
+        let mut writer = writer;
+        let buffer = self.buffer.lock().expect("poisoned");
+
+        postcard::to_io(&self.base_time, &mut writer).unwrap();
+        postcard::to_io(&self.start_time, &mut writer).unwrap();
+        postcard::to_io(&self.end_time, &mut writer).unwrap();
+
+        postcard::to_io(&buffer.objects.len(), &mut writer).unwrap();
+        for object_data in buffer.objects.values() {
+            writer.write_all(object_data.as_slice()).unwrap();
+        }
+
+        postcard::to_io(&buffer.event_count, &mut writer).unwrap();
+        writer.write_all(buffer.events.as_slice()).unwrap();
+    }
+}
+
+/// Header for the metadata file which is stored at `<chunked-recording.rfr>/meta.rfr`
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct MetaHeader {
+    pub created_time: rec::AbsTimestamp,
+    pub base_time: AbsTimestampSecs,
+}
+
+/// A timestamp measured from the [`UNIX_EPOCH`].
+///
+/// This timestamp is absoluteand only contains the whole seconds. No sub-second component is
+/// stored.
+#[derive(Debug, Clone, Copy, Hash, Deserialize, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AbsTimestampSecs {
+    /// Whole seconds component of the timestamp, measured from the [`UNIX_EPOCH`].
+    pub secs: u64,
+}
+
+impl From<rec::AbsTimestamp> for AbsTimestampSecs {
+    fn from(value: rec::AbsTimestamp) -> Self {
+        Self { secs: value.secs }
+    }
+}
+
+impl AbsTimestampSecs {
+    pub const ZERO: Self = Self { secs: 0 };
+
+    pub fn as_micros(&self) -> u64 {
+        self.secs * 1_000_000
+    }
+}
+
+// A timestamp within a chunk.
+//
+// A chunk timestamp represents the time of an event with respect to the chunk's base time. It is
+// stored as the number of microseconds since the base time. All events within a chunk must occur
+// at the base time or afterwards.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ChunkTimestamp {
+    /// Microseconds since the chunk's base time
+    pub micros: u64,
+}
+
+impl ChunkTimestamp {
+    pub fn new(micros: u64) -> Self {
+        Self { micros }
+    }
+}
+
+/// Metadata for an [`EventRecord`].
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Meta {
+    /// The timestamp that the event occurs at.
+    pub timestamp: ChunkTimestamp,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct EventRecord {
+    pub meta: Meta,
+    pub event: Event,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum Event {
+    NewTask { id: TaskId },
+    TaskPollStart { id: TaskId },
+    TaskPollEnd { id: TaskId },
+    TaskDrop { id: TaskId },
+    WakerWake { waker: Waker },
+    WakerWakeByRef { waker: Waker },
+    WakerClone { waker: Waker },
+    WakerDrop { waker: Waker },
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Waker {
+    pub task_id: TaskId,
+    pub context: Option<TaskId>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Object {
+    Task(Task),
+}

--- a/rfr/src/lib.rs
+++ b/rfr/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod chunked;
 mod identifier;
 pub mod rec;
 


### PR DESCRIPTION
An important feature of RFR is writing recordings as a series of self
contained chunks, which can be read individually and without knowledge
of other chunks.

This commit adds the initial implementation to write chunks to disk,
including both the data structures in the `rfr` crate as well as a new
`tracing-subscriber` Layer in the `rfr-subscriber` crate which will
write chunks from the tracing instrumentation in tokio.

A new example has been added to the `rfr-subscriber` which runs the
"spawn" example, but with the `RfrChunkedLayer`.

Currently, the chunks are not written on a schedule, as is planned.
Instead, all the thread chunks are stored until the layer's flusher has
flush called on it. This is only an intermediate state. Additionally,
there is no support for reading a chunked flight recording yet.