### PR TITLE
feat(rfr,viz): read and visualize chunked recordings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,7 @@ dependencies = [
  "jiff",
  "postcard",
  "serde",
+ "walkdir",
 ]
 
 [[package]]
@@ -465,6 +466,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -682,6 +692,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +722,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/rfr-subscriber/examples/ping-pong-chunked.rs
+++ b/rfr-subscriber/examples/ping-pong-chunked.rs
@@ -1,0 +1,66 @@
+use std::future::Future;
+
+use tokio::sync::mpsc;
+
+use rfr_subscriber::RfrChunkedLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let rfr_layer = RfrChunkedLayer::new("./chunked-ping-pong.rfr");
+    let flusher = rfr_layer.flusher();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let (up_tx, up_rx) = mpsc::channel::<()>(1);
+        let (dn_tx, dn_rx) = mpsc::channel::<()>(1);
+
+        let join_handles = vec![
+            spawn_named("ping", ping_pong(3, up_tx, dn_rx)),
+            spawn_named("pong", ping_pong(3, dn_tx.clone(), up_rx)),
+        ];
+
+        // serve
+        dn_tx.send(()).await.unwrap();
+
+        for jh in join_handles {
+            jh.await.unwrap();
+        }
+    });
+
+    flusher.flush();
+}
+
+async fn ping_pong(count: usize, tx: mpsc::Sender<()>, mut rx: mpsc::Receiver<()>) {
+    for _ in 0..count {
+        match rx.recv().await {
+            Some(_) => {
+                // received something!
+            }
+            None => break,
+        }
+
+        match tx.send(()).await {
+            Ok(_) => {
+                // sent something!
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[track_caller]
+fn spawn_named<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}

--- a/rfr/Cargo.toml
+++ b/rfr/Cargo.toml
@@ -16,3 +16,4 @@ keywords = ["tracing", "debugging"]
 jiff = "0.1"
 postcard = { version = "1.0.8", features = ["alloc", "use-std"] }
 serde = { version = "1.0.203", features = ["derive"] }
+walkdir = "2"

--- a/rfr/src/common.rs
+++ b/rfr/src/common.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct TaskId(u64);
+
+impl From<u64> for TaskId {
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl TaskId {
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub enum TaskKind {
+    Task,
+    Local,
+    Blocking,
+    BlockOn,
+    Other(String),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct Task {
+    pub task_id: TaskId,
+    pub task_name: String,
+    pub task_kind: TaskKind,
+
+    pub context: Option<TaskId>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Waker {
+    pub task_id: TaskId,
+    pub context: Option<TaskId>,
+}
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub enum Event {
+    NewTask { id: TaskId },
+    TaskPollStart { id: TaskId },
+    TaskPollEnd { id: TaskId },
+    TaskDrop { id: TaskId },
+    WakerWake { waker: Waker },
+    WakerWakeByRef { waker: Waker },
+    WakerClone { waker: Waker },
+    WakerDrop { waker: Waker },
+}

--- a/rfr/src/lib.rs
+++ b/rfr/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod chunked;
+pub mod common;
 mod identifier;
 pub mod rec;
 


### PR DESCRIPTION
The `rfr` crate now has a `Recording` struct that is able to lazy load a
recording made up of multiple chunks. It then exposes simple versions of
the data structures in the chunks which can be used to read out the
data.

As part of this, the `rfr-viz` crate has been modified to be generic
over the format of recording, streaming or chunked. This was done by
converting both formats to a standard representation of "task + event"
objects, which is not that far off what the streaming format was already
creating.

The `rfr-viz` binary will now pick the recording format to decode based
on whether the parameter that it is given is a plain file (streaming) or
a directory (chunked). This is a little hacky, but it will work for the
time being.

This binary also outputs a bunch of intermediate debug output to stdout.
This is left for the time being as an aid to future work (although it
should really be removed at some point).

A new ping-pong example using the chunked tracing-subscriber layer has
been added to test.