### PR TITLE
fix(viz): fix reading from multi-threaded chunked recordings

### DIFF
--- a/rfr-subscriber/examples/ping-pong-chunked.rs
+++ b/rfr-subscriber/examples/ping-pong-chunked.rs
@@ -10,7 +10,8 @@ fn main() {
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
         .enable_all()
         .build()
         .unwrap();

--- a/rfr-subscriber/examples/spawn.rs
+++ b/rfr-subscriber/examples/spawn.rs
@@ -8,7 +8,8 @@ fn main() {
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 
-    let rt = tokio::runtime::Builder::new_current_thread()
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
         .enable_all()
         .build()
         .unwrap();


### PR DESCRIPTION
There was an error in `rfr-viz` when reading from chunked recordings
of a multi-threaded tokio runtime. This was due to overwriting events
from one sequence with those from another, instead of appending (and
then sorting) them into a single list.

This change fixes the implementation error in `rfr-viz` and switches the
two `rfr-subscriber` examples which emit chunked recordings to use
multi-threaded tokio runtimes with 2 worker threads.

The `rfr-viz` code was also modified to reduce the `stdout` output a bit
(but there's still quite a lot).