### PR TITLE
feat(subscriber): write chunks as they are completed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,5 +118,9 @@ jobs:
 
       - name: Spawn (chunked)
         run: cargo run -p rfr-subscriber --example spawn-chunked && cargo run -p rfr-viz -- chunked-spawn.rfr --name spawn-chunked
+
       - name: Ping pong (chunked)
         run: cargo run -p rfr-subscriber --example ping-pong-chunked && cargo run -p rfr-viz -- chunked-ping-pong.rfr --name ping-pong-chunked
+
+      - name: Barrier (chunked)
+        run: cargo run -p rfr-subscriber --example barrier && cargo run -p rfr-viz -- chunked-barrier.rfr --name barrier

--- a/rfr-subscriber/examples/barrier.rs
+++ b/rfr-subscriber/examples/barrier.rs
@@ -1,0 +1,62 @@
+use std::{future::Future, sync::Arc, time::Duration};
+
+use tokio::sync::Barrier;
+use tracing_subscriber::prelude::*;
+
+use rfr_subscriber::RfrChunkedLayer;
+
+fn main() {
+    let rfr_layer = RfrChunkedLayer::new("./chunked-barrier.rfr");
+    let flusher = rfr_layer.flusher();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        spawn_named("main-task", async move {
+            let task_count = 10;
+            let mut handles = Vec::with_capacity(task_count);
+            let barrier = Arc::new(Barrier::new(task_count));
+            for i in 0..task_count {
+                let c = barrier.clone();
+                let task_name = format!("task-{}", i);
+                handles.push(spawn_named(&task_name, async move {
+                    tokio::time::sleep(Duration::from_micros(i as u64)).await;
+                    c.wait().await
+                }));
+            }
+
+            // Will not resolve until all "after wait" messages have been printed
+            let mut num_leaders = 0;
+            for handle in handles {
+                let wait_result = handle.await.unwrap();
+                if wait_result.is_leader() {
+                    num_leaders += 1;
+                }
+            }
+
+            // Exactly one barrier will resolve as the "leader"
+            assert_eq!(num_leaders, 1);
+        })
+        .await
+        .unwrap();
+    });
+
+    flusher.flush();
+}
+
+#[track_caller]
+fn spawn_named<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}

--- a/rfr/src/rec.rs
+++ b/rfr/src/rec.rs
@@ -57,9 +57,14 @@ impl From<Duration> for AbsTimestamp {
 }
 
 impl AbsTimestamp {
-    /// Get an `AbsTimestamp` representing the current time.
+    /// Get an absolute timestamp representing the current time.
     pub fn now() -> Self {
         SystemTime::now().duration_since(UNIX_EPOCH).unwrap().into()
+    }
+
+    /// Return the [`Duration`] since the UNIX epoch represented by this absolute timestamp.
+    pub fn as_duration_since_epoch(&self) -> Duration {
+        Duration::new(self.secs, self.subsec_micros * 1_000)
     }
 }
 


### PR DESCRIPTION
The chunked recording format splits the recording into separate files -
each one representing one chunk of the recording, which is a specific
time interval.

The chunked tracing layer collected the chunks, but they were only
written at the end of the execution. Until that point, all chunks were
kept in memory - which loses the whole benefit of the chunked format.

This change adds support to the `ChunkedWriter` to write only completed
chunks out. The method then provides a duration until the next chunk
would be ready. The chunked layer uses this new interface, spawning a
dedicated thread to write out completed chunks and then sleeping until
the next chunks will be ready.

Additionally, a new example has been added which creates a Tokio Barrier
and synchronizes on it.