### PR TITLE
docs(rfr): describe format for storing spans and events

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,5 +8,7 @@
   - [Common](file-format/common.md)
   - [Streaming](file-format/streaming.md)
   - [Chunked](file-format/chunked.md)
+    - [Meta](file-format/chunked_meta.md)
+    - [Callsites](file-format/chunked_callsites.md)
 
 [Glossary](glossary.md)

--- a/docs/src/file-format/chunked_callsites.md
+++ b/docs/src/file-format/chunked_callsites.md
@@ -1,0 +1,31 @@
+# Callsites
+
+The callsites are stored in a separate file for the entire recording. Callsites are expected to be
+static, so an append only list will be bounded by the total number of callsites in the instrumented
+application.
+
+
+## Format identifier
+
+The chunked recording callsites file has the variant identifier `rfc-cc`. This chapter describes the
+format for version `rfr-cc/0.0.1`.
+
+For a description of the identifer encoding see the [Format identifier](format-identifier.md)
+chapter.
+
+## Structure
+
+The callsite objects are stored as repeated elements until the end of the callsites file. These
+objects will be added to during the execution of the instrumented application.
+
+| Element            | Representation                       |
+|--------------------|--------------------------------------|
+| format\_identifier | [`string`] (see [Format Identifier]) |
+| callsites          | [Callsite] (repeats)                 |
+
+Typically, most callsites will be collected at the beginning of the recording, however further
+callsites may be collected at any time.
+
+[Format Identifier]: #format-identifier
+
+[Callsite]: common.md#callsite

--- a/docs/src/file-format/chunked_meta.md
+++ b/docs/src/file-format/chunked_meta.md
@@ -1,0 +1,39 @@
+# Meta
+
+The recording metadata contains configuration for a chunked recording.
+
+## Format identifier
+
+The chunked recording metadata file has the variant identifier `rfc-cm`. This chapter describes the
+format for version `rfr-cm/0.0.1`.
+
+For a description of the identifer encoding see the [Format identifier](format-identifier.md)
+chapter.
+
+## Structure
+
+| Element            | Representation                       |
+|--------------------|--------------------------------------|
+| format\_identifier | [`string`] (see [Format Identifier]) |
+| header             | [MetaHeader]                         |
+
+
+## MetaHeader
+
+The metadata header contains the initial creation time and a list of format identifiers for other
+files in this recording.
+
+| Element             | Representation                           |
+|---------------------|------------------------------------------|
+| created\_time       | [AbsTimestamp]                           |
+| format\_identifiers | \[[`string`]\] (see [Format Identifier]) |
+
+The format identifiers are all those that are used in this chunked recording. There will only be up
+to one format identifier for each variant.
+
+[Format Identifier]: #format-identifier
+
+[MetaHeader]: #metaheader
+[AbsTimestamp]: common.md#abstimestamp
+
+[`string`]: https://postcard.jamesmunns.com/wire-format#15---string

--- a/docs/src/file-format/common.md
+++ b/docs/src/file-format/common.md
@@ -3,15 +3,117 @@
 A number of data structures are common between the [streaming](streaming.md) and
 [chunked](chunked.md) file formats.
 
+## Time
+
+### AbsTimestamp
+
+An absolute timestamp measured as time since the UNIX epoch (`1970-01-01T00:00Z`). The time is
+stored as seconds and sub-seconds as microsecond precision.
+
+| Element        | Representation  |
+|----------------|-----------------|
+| secs           | [`varint(u64)`] |
+| subsec\_micros | [`varint(u32)`] |
+
+
+## Generic objects and actions
+
+### Callsite
+
+A callsite represents the location in the instrumented application's source (code) where
+instrumentation is emitted from.
+
+| Element             | Representation               |
+|---------------------|------------------------------|
+| callsite\_id        | [CallsiteId]                 |
+| level               | [Level]                      |
+| kind                | [Kind]                       |
+| const\_fields       | \[[Field]\]                  |
+| const\_field\_names | \[[FieldName]\]              |
+
+A callsite contains const data for a span, event, or other object. This data will not change during
+the runtime of the instrumented.
+
+A callsite maps to the Metadata struct from `tracing`, the following fields on the struct are stored
+as `const_fields`:
+- `name`
+- `target`
+- `module_path`
+- `file`
+- `line`
+
+The remaining fields whose names, but not values are constant for the instrumented application's
+runtime are stored in `const_field_names`.
+
+### CallsiteId
+
+The callsite Id defines a unique callsite. It is stored as a [`newtype_struct`] of a single
+[`varint(u64)`].
+
+### Span
+
+A span represents a period of time, within which the span may change from active to inactive
+multiple times during its lifetime.
+
+A span is a generic object which can be stored based on available information and later interpreted
+by the reader of a flight recording.
+
+| Element              | Representation         |
+|----------------------|------------------------|
+| iid                  | [InstrumentationId]    |
+| callsite\_id         | [CallsiteId]           |
+| parent               | [Parent]               |
+| const\_field\_values | \[[FieldValue]\]       |
+| dynamic\_fields      | \[[Field]\]            |
+
+### InstrumentationId
+
+The instrumentation Id is the instrumentation defined identifier for an object stored as a
+[`newtype_struct`] of a single [`varint(u64)`].
+
+This Id is used to link actions (FIXME(hds): link to sections for streamed and chunked) to the
+objects (FIXME(hds): link to sections for streamed and chunked) that they are affecting.
+
+When using tracing to generate the instrumentation, tracing's
+[`span::Id`](https://docs.rs/tracing/0.1/tracing/span/struct.Id.html) can be used for the
+instrumentation Id.
+
+
+### Event
+
+An event represents a moment in time.
+
+An event is a generic action which can be stored with the available information and interpreted by
+the reader of the flight recording.
+
+| Element              | Representation         |
+|----------------------|------------------------|
+| callsite\_id         | [CallsiteId]           |
+| parent               | [Parent]               |
+| const\_field\_values | \[[FieldValue]\]       |
+| dynamic\_fields      | \[[Field]\]            |
+
+
+### Parent
+
+| Variant        | Discriminant | Data                       |
+|----------------|--------------|----------------------------|
+| Current        | 0            |                            |
+| Root           | 1            |                            |
+| Explicit       | 2            | `iid`: [InstrumentationId] |
+
+### FieldName
 
 ### Task
 
-| Element    | Representation         |
-|------------|------------------------|
-| task\_id   | [TaskId]               |
-| task\_name | [`string`]             |
-| task\_kind | [TaskKind](#taskkind)  |
-| context    | [`option`]\([TaskId]\) |
+| Element      | Representation         |
+|--------------|------------------------|
+| iid          | [InstrumentationId]    |
+| callsite\_id | [CallsiteId]           |
+| task\_id     | [TaskId]               |
+| task\_name   | [`string`]             |
+| task\_kind   | [TaskKind](#taskkind)  |
+| context      | [`option`]\([TaskId]\) |
 
 
 ### TaskId
@@ -47,6 +149,10 @@ the waker action occurred, specifically when it occurred within a task.
 | context    | [`option`]\([TaskId]\) |
 
 
+[InstrumentationId]: #instrumentationid
+[CallsiteId]: #callsiteid
+[Parent]: #parent
+[TaskId]: #taskid
 [TaskId]: #taskid
 
 [tagged union]: https://postcard.jamesmunns.com/wire-format#tagged-unions

--- a/docs/src/file-format/streaming.md
+++ b/docs/src/file-format/streaming.md
@@ -13,7 +13,7 @@ stream can be performed during execution.
 ## Format identifier
 
 The streaming file format has the variant identifier `rfr-s`. This chapter describes the format for
-version `rfr-s/0.0.3`.
+version `rfr-s/0.0.4`.
 
 For a description of the identifer encoding see the [Format identifier](format-identifier.md)
 chapter.
@@ -34,16 +34,16 @@ When reading, care must be taken to respect the end of the file or stream that t
 is being read from.
 
 When the instrumented application terminates, a token record should indicate that no more records
-will be written. This uses the `End` variant of the [Event](#event) stored in the final record.
+will be written. This uses the `End` variant of the [RecordData](#recorddata) stored in the final record.
 
 ### Record
 
-A record contains timing metadata and a single event.
+A record contains timing metadata and record data.
 
-| Element | Representation  |
-|---------|-----------------|
-| meta    | [Meta](#meta)   |
-| event   | [Event](#Event) |
+| Element | Representation |
+|---------|----------------|
+| meta    | [Meta](#meta)  |
+| record  | [RecordData]   |
 
 
 ### Meta
@@ -52,37 +52,41 @@ A record contains timing metadata and a single event.
 |-----------|-----------------|
 | timestamp | [AbsTimestamp]  |
 
-### AbsTimestamp
 
-An absolute timestamp measured as time since the UNIX epoch (`1970-01-01T00:00Z`). The time is
-stored as seconds and sub-seconds as microsecond precision.
+### RecordData
 
-| Element        | Representation  |
-|----------------|-----------------|
-| secs           | [`varint(u64)`] |
-| subsec\_micros | [`varint(u32)`] |
-
-
-### Event
-
-Event is a [tagged union] that contains objects and events concerning those objects.
+Record data is a [tagged union] that contains objects and actions concerning those objects.
 
 | Variant        | Discriminant | Data                        |
 |----------------|--------------|-----------------------------|
-| Task           | 0            | [Task]                      |
-| NewTask        | 1            | `id`: [TaskId]              |
-| TaskPollStart  | 2            | `id`: [TaskId]              |
-| TaskPollEnd    | 3            | `id`: [TaskId]              |
-| TaskDrop       | 4            | `id`: [TaskId]              |
-| WakerWake      | 5            | `waker`: [Waker]            |
-| WakerWakeByRef | 6            | `waker`: [Waker]            |
-| WakerClone     | 7            | `waker`: [Waker]            |
-| WakerDrop      | 8            | `waker`: [Waker]            |
-| End            | 9            |                             |
+| End            | 0            |                             |
+| Callsite       | 1            | [Callsite]                  |
+| Span           | 2            | [Span]                      |
+| Event          | 3            | [Event]                     |
+| Task           | 4            | [Task]                      |
+| SpanNew        | 5            | `iid`: [InstrumentationId]  |
+| SpanEnter      | 6            | `iid`: [InstrumentationId]  |
+| SpanExit       | 7            | `iid`: [InstrumentationId]  |
+| SpanClose      | 8            | `iid`: [InstrumentationId]  |
+| TaskNew        | 9            | `iid`: [InstrumentationId]  |
+| TaskPollStart  | 10           | `iid`: [InstrumentationId]  |
+| TaskPollEnd    | 11           | `iid`: [InstrumentationId]  |
+| TaskDrop       | 12           | `iid`: [InstrumentationId]  |
+| WakerWake      | 13           | `waker`: [Waker]            |
+| WakerWakeByRef | 14           | `waker`: [Waker]            |
+| WakerClone     | 15           | `waker`: [Waker]            |
+| WakerDrop      | 16           | `waker`: [Waker]            |
 
 
-[AbsTimestamp]: #abstimestamp
+[Record]: #record
+[RecordData]: #recorddata
 
+[AbsTimestamp]: common.md#abstimestamp
+
+[Callsite]: common.md#callsite
+[Span]: common.md#span
+[InstrumentationId]: common.md#instrumentationid
+[Event]: common.md#event
 [Task]: common.md#task
 [TaskId]: common.md#taskid
 [Waker]: common.md#waker


### PR DESCRIPTION
The current version of the RFR file format records tasks as well as task
lifecycle events and waker events. This is already useful to describing
async applications, but is quite narrow.

One often requested feature of Tokio Console is to show spans and events
that occur within the context of tasks. This would allow a developer to
further instrument their own code and see that instrumentation overlaid
with the information about how the async runtime is operating.

This change to the RFR file format includes the necessary definitions to
record generic spans and events. While it stays quite close to the model
that tracing uses, some effort has been made to generalize the
definitioin.

Since in the current implementation, spans and tasks share an ID, this
has been included as the `InstrumentationId`, which is what will link
record data to objects. This will mean that a streaming implementation
no longer needs to keep an instrumentation ID to task ID map for all
active tasks.

Callsites will also be stored separately (since they are often shared
between many objects). In the chunked format, this storage will be
central for the entire recording, as the storage size is expected to be
minimal and it reduces the per chunk overhead, both for processing and
storage.

As we will now have a type of what was previously called `Event` which
represents a tracing event, some renaming was necessary. In the chunked
file format an `EventRecord` is now called a `Record` and and `Event` is
now called `RecordData`. In the streaming file format, an `Event` is now
`RecordData` so the chunked and streaming formats are more closesly
aligned.

Additionally, separate format identifiers have been specified for the
chunked file format meta file as well as a new file for storing
callsites (centrally for an entire chunked recording).

No code changes are included in this update.