### PR TITLE
rfr: impl De/Serialize for `FormatIdentifier`

### DIFF
--- a/rfr/src/rec.rs
+++ b/rfr/src/rec.rs
@@ -194,7 +194,7 @@ pub fn from_file(filename: String) -> Vec<Record> {
         return Vec::new();
     };
 
-    let version = FormatIdentifier::try_from_io(file_buffer.0).unwrap();
+    let (version, _): (FormatIdentifier, _) = postcard::from_io(file_buffer).unwrap();
     let current = current_software_version();
     if !current.can_read_version(&version) {
         panic!("Software version {current} cannot read file format version {version}",);

--- a/rfr/tests/identifier_serde.rs
+++ b/rfr/tests/identifier_serde.rs
@@ -1,0 +1,89 @@
+use rfr::{FormatIdentifier, FormatVariant};
+
+#[test]
+fn rfr_s_roundtrip() {
+    let version = FormatIdentifier {
+        variant: FormatVariant::RfrStreaming,
+        major: 0,
+        minor: 1,
+        patch: 2,
+    };
+
+    let buffer = postcard::to_stdvec(&version).unwrap();
+    let deser_version: FormatIdentifier = postcard::from_bytes(buffer.as_slice()).unwrap();
+    assert_eq!(version, deser_version);
+}
+
+#[test]
+fn rfr_s_serialize() {
+    let version = FormatIdentifier {
+        variant: FormatVariant::RfrStreaming,
+        major: 0,
+        minor: 1,
+        patch: 2,
+    };
+
+    let buffer = postcard::to_stdvec(&version).unwrap();
+    let expected = postcard::to_stdvec("rfr-s/0.1.2").unwrap();
+
+    assert_eq!(buffer, expected);
+}
+
+#[test]
+fn rfr_s_deserialize() {
+    let expected = FormatIdentifier {
+        variant: FormatVariant::RfrStreaming,
+        major: 0,
+        minor: 1,
+        patch: 2,
+    };
+
+    let buffer = postcard::to_stdvec("rfr-s/0.1.2").unwrap();
+    let version: FormatIdentifier = postcard::from_bytes(buffer.as_slice()).unwrap();
+
+    assert_eq!(version, expected);
+}
+
+#[test]
+fn roundtrip_rfr_c_version() {
+    let version = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+
+    let buffer = postcard::to_stdvec(&version).unwrap();
+    let deser_version: FormatIdentifier = postcard::from_bytes(buffer.as_slice()).unwrap();
+    assert_eq!(version, deser_version);
+}
+
+#[test]
+fn rfr_c_serialize() {
+    let version = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+
+    let buffer = postcard::to_stdvec(&version).unwrap();
+    let expected = postcard::to_stdvec("rfr-c/3.4.652").unwrap();
+
+    assert_eq!(buffer, expected);
+}
+
+#[test]
+fn rfr_c_deserialize() {
+    let expected = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+
+    let buffer = postcard::to_stdvec("rfr-c/3.4.652").unwrap();
+    let version: FormatIdentifier = postcard::from_bytes(buffer.as_slice()).unwrap();
+
+    assert_eq!(version, expected);
+}


### PR DESCRIPTION
The `FormatIdentifier` struct is used as a header in streaming and
chunked recording formats. The format identifier is defined as
serializing to a string format, which makes it easy for a human to read
it out when looking at the binary file in a hex editor or just a text
editor.

However, the `FormatIdentifier` struct didn't implement `Serialize` or
`Deserialize` (from `serde`), because with this string format, the
derive macros don't give us what we want. Instead we wrote it out to a
string format and then serialized or deserialized to a string and then
convert.

This change "manually" implements `Serialize` and `Deserialize` to write
it out to or read it in from the string representation directly. The
code in `rfr` has been updated to use calls to `postcard` directly.