### PR TITLE
feat: add format identifiers to chunked meta file

### DIFF
--- a/rfr-viz/src/collect.rs
+++ b/rfr-viz/src/collect.rs
@@ -158,11 +158,7 @@ pub(crate) fn streaming_recording_info(path: String) -> Option<RecordingInfo> {
 pub(crate) fn chunked_recording_info(path: String) -> Option<RecordingInfo> {
     let mut recording = chunked::from_path(path).unwrap();
     recording.load_all_chunks();
-    println!(
-        "Recording: {} {:?}",
-        recording.identifier(),
-        recording.meta()
-    );
+    println!("Recording: {:?}", recording.meta());
     for chunk in recording.chunks_lossy() {
         let Some(chunk) = chunk else { continue };
         println!("\n--------------------------------");

--- a/rfr/src/chunked/meta.rs
+++ b/rfr/src/chunked/meta.rs
@@ -1,0 +1,133 @@
+//! Chunked recording metadata
+//!
+//! The recording metadata contains configuration for a chunked recording.
+//!
+//! See the [`ChunkedMeta`] struct for details of the contents.
+
+use std::io;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{identifier::ReadFormatIdentifierError, rec, FormatIdentifier, FormatVariant};
+
+/// The format identifier for the Meta file
+pub fn version() -> FormatIdentifier {
+    FormatIdentifier {
+        variant: FormatVariant::RfrChunkedMeta,
+        major: 0,
+        minor: 0,
+        patch: 1,
+    }
+}
+
+/// Meta file contents
+///
+/// This struct can be used to serialize and deserialize the chunked recording meta file which is
+/// stored at `<chunked-recording.rfr>/meta.rfr`.
+///
+/// The metadata for a recording includes the time that the recording was created. This time should
+/// not be after the creation time of any chunks in the recording, but is otherwise only present
+/// for user reference.
+///
+/// There is also a list of format identifiers which may be used in the recording. Software that is
+/// going to read a recording can check that it is able to read all parts of the recording before
+/// beginning.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChunkedMeta {
+    /// Format identifier for the meta file, the variant should be `rfr-cm`.
+    pub format_identifier: FormatIdentifier,
+
+    /// Meta file header.
+    pub header: ChunkedMetaHeader,
+}
+
+impl ChunkedMeta {
+    /// Create new meta file contents with the provided format identifiers.
+    ///
+    /// The creation time will be set to the current time.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the `format_identifiers` vector is empty.
+    pub fn new(format_identifiers: Vec<FormatIdentifier>) -> Self {
+        assert!(
+            !format_identifiers.is_empty(),
+            "at least the `rfr-c` format identifier must be supplied"
+        );
+
+        Self {
+            format_identifier: version(),
+            header: ChunkedMetaHeader {
+                created_time: rec::AbsTimestamp::now(),
+                format_identifiers,
+            },
+        }
+    }
+
+    /// Read from a recording meta file.
+    ///
+    /// This method will attempt to load the contents of a meta recording file and return a Meta
+    /// object.
+    pub fn try_from_io(reader: impl io::Read) -> Result<Self, MetaTryFromIoError> {
+        let mut reader = reader;
+
+        let format_identifier = FormatIdentifier::try_from_io(&mut reader)
+            .map_err(MetaTryFromIoError::InvalidFormatIdentifier)?;
+
+        let current_version = version();
+        if !current_version.can_read_version(&format_identifier) {
+            return Err(MetaTryFromIoError::IncompatibleFormat(format_identifier));
+        }
+
+        let mut buffer = Vec::new();
+        let _size = reader
+            .read_to_end(&mut buffer)
+            .map_err(MetaTryFromIoError::ReadFileFailed)?;
+
+        let header: ChunkedMetaHeader =
+            postcard::from_bytes(buffer.as_slice()).map_err(MetaTryFromIoError::FileInvalid)?;
+
+        // TODO(hds): We should check that the necessary format identifiers are present. Right now,
+        // that means `rfr-c`.
+        if header.format_identifiers.is_empty() {
+            return Err(MetaTryFromIoError::MissingFormatIdentifiers);
+        }
+
+        Ok(ChunkedMeta {
+            format_identifier,
+            header,
+        })
+    }
+}
+
+/// An error returned when attempting to read a recording meta file.
+#[derive(Debug)]
+pub enum MetaTryFromIoError {
+    /// An underlying IO error when reading the file.
+    ReadFileFailed(io::Error),
+    /// The format identifier at the beginning of the file is malformed.
+    InvalidFormatIdentifier(ReadFormatIdentifierError),
+    /// The meta file is written in an incompatible format.
+    IncompatibleFormat(FormatIdentifier),
+    /// The file is not a valid Meta object serialized to [Postcard].
+    ///
+    /// [Postcard]: crate@postcard
+    FileInvalid(postcard::Error),
+    /// The meta file contains no format identifiers indicating the format of the remaining files
+    /// in the recording.
+    MissingFormatIdentifiers,
+}
+
+/// Header for the chunked recording meta file.
+///
+/// See [`ChunkedMeta`] for more details and usage.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ChunkedMetaHeader {
+    /// The time that this recording was created
+    pub created_time: rec::AbsTimestamp,
+
+    /// All the format identifiers used in this chunked recording
+    ///
+    /// Only one format identifier for each variant should be included.
+    pub format_identifiers: Vec<FormatIdentifier>,
+}

--- a/rfr/src/identifier.rs
+++ b/rfr/src/identifier.rs
@@ -12,6 +12,8 @@ pub enum FormatVariant {
     RfrStreaming,
     /// The chunked RFR variant. The string representation is `rfr-c`.
     RfrChunked,
+    /// The chunked RFR meta file. The string representation is `rfr-cm`.
+    RfrChunkedMeta,
 }
 
 impl fmt::Display for FormatVariant {
@@ -25,6 +27,7 @@ impl FormatVariant {
         match s {
             "rfr-s" => Some(Self::RfrStreaming),
             "rfr-c" => Some(Self::RfrChunked),
+            "rfr-cm" => Some(Self::RfrChunkedMeta),
             _ => None,
         }
     }
@@ -33,6 +36,7 @@ impl FormatVariant {
         match self {
             Self::RfrStreaming => "rfr-s",
             Self::RfrChunked => "rfr-c",
+            Self::RfrChunkedMeta => "rfr-cm",
         }
     }
 }

--- a/rfr/tests/meta.rs
+++ b/rfr/tests/meta.rs
@@ -1,0 +1,136 @@
+// TODO(hds): Write tests for meta file handling
+use rfr::{
+    chunked::{ChunkedMeta, ChunkedMetaHeader, MetaTryFromIoError},
+    rec::AbsTimestamp,
+    FormatIdentifier, FormatVariant,
+};
+
+#[test]
+fn round_trip_meta() {
+    let chunked_identifier = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+    let meta = ChunkedMeta::new(vec![chunked_identifier.clone()]);
+
+    let buffer = postcard::to_stdvec(&meta).unwrap();
+    let deser_meta: ChunkedMeta = postcard::from_bytes(buffer.as_slice()).unwrap();
+
+    assert_eq!(meta.format_identifier, deser_meta.format_identifier);
+    assert_eq!(meta.header.created_time, deser_meta.header.created_time);
+    assert_eq!(meta.header.format_identifiers, vec![chunked_identifier]);
+}
+
+// TODO(hds): also test with a method on ChunkedMeta that correctly checks the version in the meta
+// file. Then check that we correctly identify when the version can't be read.
+
+#[test]
+fn try_from_io_success() {
+    // If this test fails, maybe this identifier needs to be updated.
+    let chunked_identifier = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+    let meta = ChunkedMeta::new(vec![chunked_identifier.clone()]);
+
+    let buffer = postcard::to_stdvec(&meta).unwrap();
+
+    let read_meta = ChunkedMeta::try_from_io(buffer.as_slice()).unwrap();
+
+    assert_eq!(meta.format_identifier, read_meta.format_identifier);
+    assert_eq!(meta.header.created_time, read_meta.header.created_time);
+    assert_eq!(meta.header.format_identifiers, vec![chunked_identifier]);
+}
+
+#[test]
+fn try_from_io_invalid_format_identifier() {
+    let buffer = [0_u8, 0_u8];
+    let result = ChunkedMeta::try_from_io(buffer.as_slice());
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(MetaTryFromIoError::InvalidFormatIdentifier(_))
+    ));
+}
+
+#[test]
+fn try_from_io_incompatible_format() {
+    let chunked_identifier = FormatIdentifier {
+        variant: FormatVariant::RfrChunked,
+        major: 3,
+        minor: 4,
+        patch: 652,
+    };
+    let meta = ChunkedMeta {
+        format_identifier: FormatIdentifier {
+            variant: FormatVariant::RfrChunkedMeta,
+            major: 100,
+            minor: 0,
+            patch: 0,
+        },
+        header: ChunkedMetaHeader {
+            created_time: AbsTimestamp::now(),
+            format_identifiers: vec![chunked_identifier],
+        },
+    };
+
+    let buffer = postcard::to_stdvec(&meta).unwrap();
+    let result = ChunkedMeta::try_from_io(buffer.as_slice());
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(MetaTryFromIoError::IncompatibleFormat(FormatIdentifier {
+            variant: FormatVariant::RfrChunkedMeta,
+            ..
+        }))
+    ));
+}
+
+#[test]
+fn try_from_io_file_invalid() {
+    let format_identifier = FormatIdentifier {
+        variant: FormatVariant::RfrChunkedMeta,
+        major: 0,
+        minor: 0,
+        patch: 1,
+    };
+
+    let mut buffer = postcard::to_stdvec(&format_identifier).unwrap();
+    buffer.append(&mut vec![0xff, 0xff]);
+    let result = ChunkedMeta::try_from_io(buffer.as_slice());
+
+    assert!(result.is_err());
+    assert!(matches!(result, Err(MetaTryFromIoError::FileInvalid(_)),));
+}
+
+#[test]
+fn try_from_io_missing_format_identifiers() {
+    let meta = ChunkedMeta {
+        format_identifier: FormatIdentifier {
+            variant: FormatVariant::RfrChunkedMeta,
+            major: 0,
+            minor: 0,
+            patch: 1,
+        },
+        header: ChunkedMetaHeader {
+            created_time: AbsTimestamp::now(),
+            format_identifiers: vec![],
+        },
+    };
+
+    let buffer = postcard::to_stdvec(&meta).unwrap();
+
+    let result = ChunkedMeta::try_from_io(buffer.as_slice());
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result,
+        Err(MetaTryFromIoError::MissingFormatIdentifiers),
+    ));
+}


### PR DESCRIPTION
In the recording format changes described in #14, a list of format
identifiers was added to the chunked recording meta file. Additionally,
separate format identifiers were specified for each file type, such that
the meta file gets its own format identifier.

The list of format identifiers contains all the (other) format
identifiers used in the recording, allowing software that is attempting
to read the chunked recording to check compatibility based on the meta
file alone.

This change updates reading and writing of the meta file to match the
new format. Additionally, the structs and logic for the meta file have
been moved to a dedicated module, as we slowly clean up the mess of code
in the `chunked` module.