### PR TITLE
docs(rfr): define `Callsite` fields

### DIFF
--- a/docs/src/file-format/common.md
+++ b/docs/src/file-format/common.md
@@ -29,7 +29,7 @@ instrumentation is emitted from.
 | level               | [Level]                      |
 | kind                | [Kind]                       |
 | const\_fields       | \[[Field]\]                  |
-| const\_field\_names | \[[FieldName]\]              |
+| split\_field\_names | \[[FieldName]\]              |
 
 A callsite contains const data for a span, event, or other object. This data will not change during
 the runtime of the instrumented.
@@ -43,12 +43,65 @@ as `const_fields`:
 - `line`
 
 The remaining fields whose names, but not values are constant for the instrumented application's
-runtime are stored in `const_field_names`.
+runtime are stored in `split_field_names`.
 
 ### CallsiteId
 
 The callsite Id defines a unique callsite. It is stored as a [`newtype_struct`] of a single
 [`varint(u64)`].
+
+### Level
+
+The level at which a span or event is recorded. Levels are tied to the callsite, so it is static
+information.
+
+The level is stored as a [`varint(u8)`]. The `tracing` levels are mapped as per the [Bunyan level
+suggestions](https://github.com/trentm/node-bunyan?tab=readme-ov-file#levels).
+
+| Value | Level |
+|-------|-------|
+| 10    | trace |
+| 20    | debug |
+| 30    | info  |
+| 40    | warn  |
+| 50    | error |
+
+### Kind
+
+The kind of a callsite indicates the type of the instrumentation that is emitted.
+
+| Variant        | Discriminant | Data |
+|----------------|--------------|------|
+| Unknown        | 0            |      |
+| Event          | 1            |      |
+| Span           | 2            |      |
+
+### Field
+
+A complete field containing the name and value together.
+
+| Element | Representation |
+|---------|----------------|
+| name    | [FieldName]    |
+| value   | [FieldValue]   |
+
+### FieldName
+
+The name of a field is represented by a [`string`].
+
+### FieldValue
+
+The value of a field. Only "basic" values are made available.
+
+| Variant | Discriminant | Data             |
+|---------|--------------|------------------|
+| F64     | 0            | [`f64`]          |
+| I64     | 1            | [`varint(i64)`]  |
+| U64     | 2            | [`varint(u64)`]  |
+| I128    | 3            | [`varint(i128)`] |
+| U128    | 4            | [`varint(i128)`] |
+| Bool    | 5            | [`bool`]         |
+| Str     | 6            | [`string`]       |
 
 ### Span
 
@@ -63,7 +116,7 @@ by the reader of a flight recording.
 | iid                  | [InstrumentationId]    |
 | callsite\_id         | [CallsiteId]           |
 | parent               | [Parent]               |
-| const\_field\_values | \[[FieldValue]\]       |
+| split\_field\_values | \[[FieldValue]\]       |
 | dynamic\_fields      | \[[Field]\]            |
 
 ### InstrumentationId
@@ -90,7 +143,7 @@ the reader of the flight recording.
 |----------------------|------------------------|
 | callsite\_id         | [CallsiteId]           |
 | parent               | [Parent]               |
-| const\_field\_values | \[[FieldValue]\]       |
+| split\_field\_values | \[[FieldValue]\]       |
 | dynamic\_fields      | \[[Field]\]            |
 
 
@@ -101,8 +154,6 @@ the reader of the flight recording.
 | Current        | 0            |                            |
 | Root           | 1            |                            |
 | Explicit       | 2            | `iid`: [InstrumentationId] |
-
-### FieldName
 
 ### Task
 
@@ -151,12 +202,24 @@ the waker action occurred, specifically when it occurred within a task.
 
 [InstrumentationId]: #instrumentationid
 [CallsiteId]: #callsiteid
+[Level]: #level
+[Kind]: #kind
+[Field]: #field
+[FieldName]: #fieldname
+[FieldValue]: #fieldvalue
 [Parent]: #parent
 [TaskId]: #taskid
 [TaskId]: #taskid
 
 [tagged union]: https://postcard.jamesmunns.com/wire-format#tagged-unions
+[`bool`]: https://postcard.jamesmunns.com/wire-format#1---bool
+[`f64`]: https://postcard.jamesmunns.com/wire-format#13---f64
 [`option`]: https://postcard.jamesmunns.com/wire-format#17---option
+[`varint(u8)`]: https://postcard.jamesmunns.com/wire-format#7---u8
+[`varint(u32)`]: https://postcard.jamesmunns.com/wire-format#9---u32
+[`varint(i64)`]: https://postcard.jamesmunns.com/wire-format#5---i64
 [`varint(u64)`]: https://postcard.jamesmunns.com/wire-format#10---u64
+[`varint(i128)`]: https://postcard.jamesmunns.com/wire-format#6---i128
+[`varint(u128)`]: https://postcard.jamesmunns.com/wire-format#11---u128
 [`string`]: https://postcard.jamesmunns.com/wire-format#15---string
 [`newtype_struct`]: https://postcard.jamesmunns.com/wire-format#21---newtype_struct


### PR DESCRIPTION
The documentation changes made in https://github.com/hds/rfr/pull/14 were missing some fields in the
`Callsite` object.

This change adds the definitions for Level, Kind, and the various Field
related objects, Field, FieldName, FieleVaue.