### PR TITLE
chore(rfr): remove needless lifetime

### DIFF
--- a/rfr/src/identifier.rs
+++ b/rfr/src/identifier.rs
@@ -279,7 +279,7 @@ impl Serialize for FormatIdentifier {
 
 struct FormatIdentifierVisitor {}
 
-impl<'de> Visitor<'de> for FormatIdentifierVisitor {
+impl Visitor<'_> for FormatIdentifierVisitor {
     type Value = FormatIdentifier;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {


### PR DESCRIPTION
Updated clippy lint indicates that this explicit lifetime is
unnecessary, so this change removes it.