### PR TITLE
feat(rfr): add callsites file

### DIFF
--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -51,7 +51,7 @@ impl RfrChunkedLayer {
     }
 
     fn spawn_writer(base_dir: String) -> WriterHandle {
-        let writer = Arc::new(ChunkedWriter::new(base_dir.to_owned()));
+        let writer = Arc::new(ChunkedWriter::try_new(base_dir.to_owned()).unwrap());
 
         let thread_writer = Arc::clone(&writer);
         let join_handle = thread::Builder::new()

--- a/rfr/src/chunked/callsite.rs
+++ b/rfr/src/chunked/callsite.rs
@@ -1,0 +1,272 @@
+//! Chunked recording callsites
+//!
+//! The callsites are all stored centrally for the entire recording.
+//!
+//! See the [`ChunkedCallsites`] struct for details of the contents.
+
+use std::{error, fmt, io};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    common::{Field, FieldName, Kind, Level},
+    identifier::{FormatIdentifier, FormatVariant, ReadFormatIdentifierError},
+};
+
+/// The format identifier for the Callsites file
+pub fn version() -> FormatIdentifier {
+    FormatIdentifier {
+        variant: FormatVariant::RfrChunkedCallsites,
+        major: 0,
+        minor: 0,
+        patch: 1,
+    }
+}
+
+/// An instrumented location in an application
+///
+/// A callsite contains all the const data for a specific location in the application where
+/// instrumentation is emitted from.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Callsite {
+    pub callsite_id: CallsiteId,
+    pub level: Level,
+    pub kind: Kind,
+    pub const_fields: Vec<Field>,
+    pub split_field_names: Vec<FieldName>,
+}
+
+/// The callsite Id defines a unique callsite.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct CallsiteId(u64);
+
+impl From<u64> for CallsiteId {
+    /// Create a CallsiteId from a `u64` value.
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl CallsiteId {
+    /// The `u64` representation of the callsite Id.
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Callsites file contents
+///
+/// This struct can be used to serialize and deserialize the chunked recording callsites file,
+/// which is stored at `<chunked-recording.rfr>/callsites.rs`.
+///
+/// The callsite for all spans and events in the recording at stored centrally. This data is static
+/// for the lifetime of a program execution and is expected to be bounded to a relatively small
+/// number of items.
+#[derive(Debug, Clone)]
+pub struct ChunkedCallsites {
+    /// Format identifier for the callsites file, the variant should be `rfr-cc`.
+    pub format_identifier: FormatIdentifier,
+
+    /// Meta file header.
+    pub callsites: Vec<Callsite>,
+}
+
+impl ChunkedCallsites {
+    /// Create a new callsites file contents with no callsites.
+    pub fn new(callsites: Vec<Callsite>) -> Self {
+        Self {
+            format_identifier: version(),
+            callsites,
+        }
+    }
+
+    // Read from a chunked recording callsites file.
+    //
+    /// This method will attempt to load the contents of a chunked recording callsites file and
+    /// return a [`ChunkedCallsites`] object.
+    pub fn try_from_io(reader: impl io::Read) -> Result<Self, CallsitesTryFromIoError> {
+        let mut reader = reader;
+
+        let format_identifier = FormatIdentifier::try_from_io(&mut reader)
+            .map_err(CallsitesTryFromIoError::InvalidFormatIdentifier)?;
+
+        let current_version = version();
+        if !current_version.can_read_version(&format_identifier) {
+            return Err(CallsitesTryFromIoError::IncompatibleFormat(
+                format_identifier,
+            ));
+        }
+
+        let mut buffer = Vec::new();
+        let _size = reader
+            .read_to_end(&mut buffer)
+            .map_err(CallsitesTryFromIoError::ReadFileFailed)?;
+
+        let mut callsites = Vec::new();
+        let mut bytes = buffer.as_slice();
+        for idx in 0.. {
+            if bytes.is_empty() {
+                break;
+            }
+
+            let (callsite, rem_bytes): (Callsite, _) = postcard::take_from_bytes(bytes)
+                .map_err(|error| CallsitesTryFromIoError::CallsiteInvalid { idx, error })?;
+            bytes = rem_bytes;
+            callsites.push(callsite);
+        }
+
+        Ok(ChunkedCallsites {
+            format_identifier,
+            callsites,
+        })
+    }
+
+    /// Write this callsites file to the provided writer.
+    ///
+    /// This method writes the entire `callsites.rfr` file out.
+    pub fn to_io(&self, writer: impl io::Write) -> Result<(), io::Error> {
+        let mut writer = writer;
+        postcard::to_io(&self.format_identifier, &mut writer)
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+
+        for callsite in &self.callsites {
+            postcard::to_io(callsite, &mut writer)
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Incrementally write a chunked recording `callsites.rfr` file.
+#[derive(Debug)]
+pub struct ChunkedCallsitesWriter<W>
+where
+    W: io::Write,
+{
+    chunked_callsites: ChunkedCallsites,
+    written_callsites: usize,
+    writer: W,
+}
+
+impl<W> ChunkedCallsitesWriter<W>
+where
+    W: io::Write,
+{
+    /// Try to create a new chunked callsites writer.
+    ///
+    /// The provided writer will be kept for the lifetime of the chunked callsite writer and used
+    /// to write callsites (added via [`push_callsite`]) during a [`flush`].
+    ///
+    /// # Errors
+    ///
+    /// This method will fail if the software defined format identifier cannot be written using the
+    /// supplied writer.
+    pub fn try_new(writer: W) -> Result<Self, NewChunkedCallsitesWriterError> {
+        let mut callsite_writer = Self {
+            chunked_callsites: ChunkedCallsites::new(Vec::new()),
+            written_callsites: 0,
+            writer,
+        };
+
+        postcard::to_io(
+            &callsite_writer.chunked_callsites.format_identifier,
+            &mut callsite_writer.writer,
+        )
+        .map_err(|inner| NewChunkedCallsitesWriterError { inner })?;
+
+        Ok(callsite_writer)
+    }
+
+    /// Return a reference to the inner [`ChunkedCallsites`]
+    pub fn chunked_callsites(&self) -> &ChunkedCallsites {
+        &self.chunked_callsites
+    }
+
+    /// Push a callsite to be written during the next [`flush`].
+    pub fn push_callsite(&mut self, callsite: Callsite) {
+        self.chunked_callsites.callsites.push(callsite);
+    }
+
+    /// Returns whether there are unwritten callsites that need to be flushed to the writer.
+    ///
+    /// If this method returns `false`, then a call to [`flush`] will be a no-op.
+    pub fn needs_flush(&mut self) -> bool {
+        self.written_callsites == self.chunked_callsites.callsites.len()
+    }
+
+    /// Flushes any unwritten callsites to the writer.
+    pub fn flush(&mut self) -> Result<(), FlushCallsitesError> {
+        if self.written_callsites >= self.chunked_callsites.callsites.len() {
+            // Nothing to flush
+            return Ok(());
+        }
+
+        let to_write = &self.chunked_callsites.callsites[self.written_callsites..];
+        for callsite in to_write {
+            postcard::to_io(callsite, &mut self.writer).map_err(|inner| FlushCallsitesError {
+                idx: self.written_callsites,
+                inner,
+            })?;
+            self.written_callsites += 1;
+        }
+
+        Ok(())
+    }
+}
+
+/// Error occuring when creating a new [`ChunkedCallsitesWriter`]
+#[derive(Debug)]
+pub struct NewChunkedCallsitesWriterError {
+    /// Inner postcard error.
+    inner: postcard::Error,
+}
+
+impl NewChunkedCallsitesWriterError {
+    pub fn inner_error(&self) -> &postcard::Error {
+        &self.inner
+    }
+}
+
+impl fmt::Display for NewChunkedCallsitesWriterError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Could not create `ChunkedCallsitesWriter`: {error}",
+            error = self.inner
+        )
+    }
+}
+impl error::Error for NewChunkedCallsitesWriterError {}
+
+/// An error that occurred while flushing callsites to writer.
+#[derive(Debug)]
+pub struct FlushCallsitesError {
+    idx: usize,
+    inner: postcard::Error,
+}
+
+impl fmt::Display for FlushCallsitesError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "failed to write callsite with index `{idx}`: {inner}",
+            idx = self.idx,
+            inner = self.inner,
+        )
+    }
+}
+impl error::Error for FlushCallsitesError {}
+
+/// An error when reading a `callsites.rfr` file from a reader.
+#[derive(Debug)]
+pub enum CallsitesTryFromIoError {
+    /// An underlying IO error when reading the file.
+    ReadFileFailed(io::Error),
+    /// The format identifier at the beginning of the file is malformed.
+    InvalidFormatIdentifier(ReadFormatIdentifierError),
+    /// The meta file is written in an incompatible format.
+    IncompatibleFormat(FormatIdentifier),
+    /// An invalid callsite was encountered.
+    CallsiteInvalid { idx: usize, error: postcard::Error },
+}

--- a/rfr/src/common.rs
+++ b/rfr/src/common.rs
@@ -1,5 +1,65 @@
 use serde::{Deserialize, Serialize};
 
+/// The level of a span or event.
+///
+/// The `tracing` levels are mapped as per the [Bunyan level suggestions].
+///
+/// | Value | Level |
+/// |-------|-------|
+/// | 10    | trace |
+/// | 20    | debug |
+/// | 30    | info  |
+/// | 40    | warn  |
+/// | 50    | error |
+///
+/// [Bunyan level suggestions]: https://github.com/trentm/node-bunyan?tab=readme-ov-file#levels
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct Level(pub u8);
+
+/// The kind of a callsite.
+///
+/// This indicates the type of instrumentation that is emitted from that location in the
+/// application code.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum Kind {
+    /// An unknown instrumentation type.
+    Unknown,
+    /// An event representing a point in time.
+    Event,
+    /// A span representing potentially disjoint periods of time.
+    Span,
+}
+
+/// A complete field containing the name and value together.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Field {
+    pub name: FieldName,
+    pub value: FieldValue,
+}
+
+/// The name (key) of a field.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct FieldName(String);
+
+/// The value of a field.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub enum FieldValue {
+    /// 64-bit floating point number.
+    F64(f64),
+    /// 64-bit signed integer.
+    I64(i64),
+    /// 64-bit unsigned integer.
+    U64(u64),
+    /// 128-bit signed integer.
+    I128(i128),
+    /// 128-bit unsigned integer.
+    U128(u128),
+    /// Boolean
+    Bool(bool),
+    /// String
+    Str(String),
+}
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct TaskId(u64);
 

--- a/rfr/src/identifier.rs
+++ b/rfr/src/identifier.rs
@@ -14,6 +14,8 @@ pub enum FormatVariant {
     RfrChunked,
     /// The chunked RFR meta file. The string representation is `rfr-cm`.
     RfrChunkedMeta,
+    /// The chunked RFR callsites file. The string representation is `rfr-cc`.
+    RfrChunkedCallsites,
 }
 
 impl fmt::Display for FormatVariant {
@@ -28,6 +30,7 @@ impl FormatVariant {
             "rfr-s" => Some(Self::RfrStreaming),
             "rfr-c" => Some(Self::RfrChunked),
             "rfr-cm" => Some(Self::RfrChunkedMeta),
+            "rfr-cc" => Some(Self::RfrChunkedCallsites),
             _ => None,
         }
     }
@@ -37,6 +40,7 @@ impl FormatVariant {
             Self::RfrStreaming => "rfr-s",
             Self::RfrChunked => "rfr-c",
             Self::RfrChunkedMeta => "rfr-cm",
+            Self::RfrChunkedCallsites => "rfr-cc",
         }
     }
 }

--- a/rfr/tests/callsite.rs
+++ b/rfr/tests/callsite.rs
@@ -1,0 +1,85 @@
+use rfr::{
+    chunked::{Callsite, CallsiteId, ChunkedCallsites, ChunkedCallsitesWriter},
+    common::{Kind, Level},
+};
+
+#[test]
+fn empty_callsites() {
+    let original = ChunkedCallsites::new(vec![]);
+    let mut buffer = Vec::new();
+
+    original.to_io(&mut buffer).unwrap();
+
+    let deser = ChunkedCallsites::try_from_io(buffer.as_slice()).unwrap();
+
+    assert_eq!(original.format_identifier, deser.format_identifier);
+    assert!(deser.callsites.is_empty());
+}
+
+#[test]
+fn minimal_callsite() {
+    let original_callsite = Callsite {
+        callsite_id: CallsiteId::from(1_u64),
+        level: Level(10),
+        kind: Kind::Event,
+        const_fields: vec![],
+        split_field_names: vec![],
+    };
+    let original = ChunkedCallsites::new(vec![original_callsite]);
+    let mut buffer = Vec::new();
+
+    original.to_io(&mut buffer).unwrap();
+
+    let deser = ChunkedCallsites::try_from_io(buffer.as_slice()).unwrap();
+
+    assert_eq!(original.format_identifier, deser.format_identifier);
+    assert_eq!(1, deser.callsites.len());
+    assert_eq!(original.callsites[0], deser.callsites[0]);
+}
+
+#[test]
+fn callsites_writer_new() {
+    let mut buffer = Vec::new();
+    let identifier = {
+        let writer = ChunkedCallsitesWriter::try_new(&mut buffer).unwrap();
+        writer.chunked_callsites().format_identifier.clone()
+    };
+
+    let chunked_callsites = ChunkedCallsites::try_from_io(buffer.as_slice()).unwrap();
+
+    assert_eq!(identifier, chunked_callsites.format_identifier);
+    assert!(chunked_callsites.callsites.is_empty());
+}
+
+#[test]
+fn callsites_writer_minimal_callsite() {
+    let callsite = Callsite {
+        callsite_id: CallsiteId::from(1_u64),
+        level: Level(10),
+        kind: Kind::Event,
+        const_fields: vec![],
+        split_field_names: vec![],
+    };
+    let mut buffer = Vec::new();
+    let identifier = {
+        let mut writer = ChunkedCallsitesWriter::try_new(&mut buffer).unwrap();
+        writer.push_callsite(callsite.clone());
+        writer.flush().unwrap();
+        writer.chunked_callsites().format_identifier.clone()
+    };
+
+    let chunked_callsites = ChunkedCallsites::try_from_io(buffer.as_slice()).unwrap();
+
+    assert_eq!(identifier, chunked_callsites.format_identifier);
+    assert_eq!(1, chunked_callsites.callsites.len());
+    assert_eq!(callsite, chunked_callsites.callsites[0]);
+}
+
+#[test]
+fn callsties_writer_new_fails() {
+    let mut buffer = [0_u8; 0];
+
+    let new_result = ChunkedCallsitesWriter::try_new(buffer.as_mut_slice());
+
+    assert!(new_result.is_err());
+}


### PR DESCRIPTION
The general callsite information for a span, event, or other
instrumentation objection doesn't change during the execution of an
application. Additionally, the number of callsites is bounded (these are
effectively instrumented points in the code). As such, it makes sense to
store that information centrally for a chunked recording.

The object data which needs to be stored in each sequence chunk can then
be reduced.

This change is the first step towards this format (which was documented
in #14 and #17). The `Callsite` struct has been defined, as well as the
structure of the central `callsites.rfr` file together with the
necessary functionality to write this file incrementally (as callsites
are recorded for the first time).

This has been connected to the `ChunkedWriter` and will cause an empty
callsites file to be created (containing just the format identifier),
but not callsite data will be recorded or written out, as the common
`rfr` objects need to be modified to use the `Callsite` first.