### PR TITLE
feat(rfr): support generic spans and events in file format

### DIFF
--- a/docs/src/file-format/streaming.md
+++ b/docs/src/file-format/streaming.md
@@ -57,25 +57,25 @@ A record contains timing metadata and record data.
 
 Record data is a [tagged union] that contains objects and actions concerning those objects.
 
-| Variant        | Discriminant | Data                        |
-|----------------|--------------|-----------------------------|
-| End            | 0            |                             |
-| Callsite       | 1            | [Callsite]                  |
-| Span           | 2            | [Span]                      |
-| Event          | 3            | [Event]                     |
-| Task           | 4            | [Task]                      |
-| SpanNew        | 5            | `iid`: [InstrumentationId]  |
-| SpanEnter      | 6            | `iid`: [InstrumentationId]  |
-| SpanExit       | 7            | `iid`: [InstrumentationId]  |
-| SpanClose      | 8            | `iid`: [InstrumentationId]  |
-| TaskNew        | 9            | `iid`: [InstrumentationId]  |
-| TaskPollStart  | 10           | `iid`: [InstrumentationId]  |
-| TaskPollEnd    | 11           | `iid`: [InstrumentationId]  |
-| TaskDrop       | 12           | `iid`: [InstrumentationId]  |
-| WakerWake      | 13           | `waker`: [Waker]            |
-| WakerWakeByRef | 14           | `waker`: [Waker]            |
-| WakerClone     | 15           | `waker`: [Waker]            |
-| WakerDrop      | 16           | `waker`: [Waker]            |
+| Variant        | Discriminant | Data                       |
+|----------------|--------------|----------------------------|
+| End            | 0            |                            |
+| Callsite       | 1            | `callsite`: [Callsite]     |
+| Span           | 2            | `span`: [Span]             |
+| Event          | 3            | `event`: [Event]           |
+| Task           | 4            | `task`: [Task]             |
+| SpanNew        | 5            | `iid`: [InstrumentationId] |
+| SpanEnter      | 6            | `iid`: [InstrumentationId] |
+| SpanExit       | 7            | `iid`: [InstrumentationId] |
+| SpanClose      | 8            | `iid`: [InstrumentationId] |
+| TaskNew        | 9            | `iid`: [InstrumentationId] |
+| TaskPollStart  | 10           | `iid`: [InstrumentationId] |
+| TaskPollEnd    | 11           | `iid`: [InstrumentationId] |
+| TaskDrop       | 12           | `iid`: [InstrumentationId] |
+| WakerWake      | 13           | `waker`: [Waker]           |
+| WakerWakeByRef | 14           | `waker`: [Waker]           |
+| WakerClone     | 15           | `waker`: [Waker]           |
+| WakerDrop      | 16           | `waker`: [Waker]           |
 
 
 [Record]: #record

--- a/rfr/src/chunked/record.rs
+++ b/rfr/src/chunked/record.rs
@@ -1,0 +1,39 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    chunked::ChunkTimestamp,
+    common::{Event, InstrumentationId, Waker},
+};
+
+/// A record containing timing metadata and record data.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Record {
+    pub meta: Meta,
+    pub data: RecordData,
+}
+
+/// Metadata for a [`Record`].
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Meta {
+    /// The timestamp that the record occurs at.
+    pub timestamp: ChunkTimestamp,
+}
+
+/// The data for a discrete
+#[non_exhaustive]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub enum RecordData {
+    SpanNew { iid: InstrumentationId },
+    SpanEnter { iid: InstrumentationId },
+    SpanExit { iid: InstrumentationId },
+    SpanClose { iid: InstrumentationId },
+    Event { event: Event },
+    TaskNew { iid: InstrumentationId },
+    TaskPollStart { iid: InstrumentationId },
+    TaskPollEnd { iid: InstrumentationId },
+    TaskDrop { iid: InstrumentationId },
+    WakerWake { waker: Waker },
+    WakerWakeByRef { waker: Waker },
+    WakerClone { waker: Waker },
+    WakerDrop { waker: Waker },
+}


### PR DESCRIPTION
Implement the changes designed in #14 and #17 which bring support for
generic spans and events into the recording file format. This is in
addition to the task spans and waker events already supported.

In this change, only the file structure changes are made, together with
all the necessary changes in the `rfr-subscriber` and `rfr-viz` crates
to support the modification to the format.

Generic spans and events are not yet actually recorded.

That said, it's a big refactor, especially since what we now call a
`Record` was previously called an `Event` (renamed because we have
events which are like tracing events now) and what is now called
`RecordData` was previously called `EventRecord`.

There is also a small change in the docs for the streaming variant of
`RecordData` is made (using structs instead of tuples for data) to align
it with the chunked variant.