### PR TITLE
chore: use justfile for running examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,18 +109,19 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
+      - uses: extractions/setup-just@v2
 
       - name: Spawn (streamed)
-        run: cargo run -p rfr-subscriber --example spawn && cargo run -p rfr-viz -- recording-spawn-stream.rfr --name spawn-stream
+        run: just spawn-streamed
 
       - name: Ping pong (streamed)
-        run: cargo run -p rfr-subscriber --example ping-pong && cargo run -p rfr-viz -- recording-ping_pong-stream.rfr --name ping-pong-stream
+        run: just ping-pong-streamed
 
       - name: Spawn (chunked)
-        run: cargo run -p rfr-subscriber --example spawn-chunked && cargo run -p rfr-viz -- chunked-spawn.rfr --name spawn-chunked
+        run: just spawn-chunked
 
       - name: Ping pong (chunked)
-        run: cargo run -p rfr-subscriber --example ping-pong-chunked && cargo run -p rfr-viz -- chunked-ping-pong.rfr --name ping-pong-chunked
+        run: just ping-pong-chunked
 
       - name: Barrier (chunked)
-        run: cargo run -p rfr-subscriber --example barrier && cargo run -p rfr-viz -- chunked-barrier.rfr --name barrier
+        run: just barrier-chunked

--- a/justfile
+++ b/justfile
@@ -1,0 +1,42 @@
+create-examples-output:
+    mkdir -p examples-output
+
+[working-directory: 'examples-output']
+spawn-streamed: create-examples-output
+    cargo run -p rfr-subscriber --example spawn
+    cargo run -p rfr-viz -- recording-spawn-stream.rfr --name spawn-stream
+
+[working-directory: 'examples-output']
+ping-pong-streamed: create-examples-output
+    cargo run -p rfr-subscriber --example ping-pong
+    cargo run -p rfr-viz -- recording-ping_pong-stream.rfr --name ping-pong-stream
+
+[working-directory: 'examples-output']
+spawn-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example spawn-chunked
+    cargo run -p rfr-viz -- chunked-spawn.rfr --name spawn-chunked
+
+[working-directory: 'examples-output']
+ping-pong-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example ping-pong-chunked
+    cargo run -p rfr-viz -- chunked-ping-pong.rfr --name ping-pong-chunked
+
+[working-directory: 'examples-output']
+barrier-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example barrier
+    cargo run -p rfr-viz -- chunked-barrier.rfr --name barrier
+
+all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked
+
+[working-directory: 'examples-output']
+clean-all:
+    rm -f barrier.html
+    rm -rf chunked-barrier.rfr
+    rm -rf chunked-ping-pong.rfr
+    rm -rf chunked-spawn.rfr
+    rm -f ping-pong-chunked.html
+    rm -f ping-pong-stream.html
+    rm -f recording-ping_pong-stream.rfr
+    rm -f recording-spawn-stream.rfr
+    rm -f spawn-chunked.html
+    rm -f spawn-stream.html


### PR DESCRIPTION
There are a number of examples in the `rfr-subscriber` crate which show
some basic usage of rfr. As a sanity check (because they are by no means
exhaustive), all these examples are run and then their output is passed
to `rfr-viz` to be read.

In order to make running those examples locally easier, they have been
added to a `justfile` to be used with the just command runner.

More details on just: https://github.com/casey/just

The CI examples job has been modified to use the `justfile`.