### PR TITLE
feat(subscriber): add thousand tasks example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,3 @@
 [workspace]
 members = ["rfr", "rfr-subscriber", "rfr-viz"]
 resolver = "2"
-rust-version = "1.84"

--- a/justfile
+++ b/justfile
@@ -25,8 +25,13 @@ ping-pong-chunked: create-examples-output
 barrier-chunked: create-examples-output
     cargo run -p rfr-subscriber --example barrier
     cargo run -p rfr-viz -- generate chunked-barrier.rfr --name barrier
+    
+[working-directory: 'examples-output']
+thousand-tasks-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example thousand-tasks
+    cargo run -p rfr-viz -- generate chunked-thousand-tasks.rfr --name thousand-tasks
 
-all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked
+all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked thousand-tasks-chunked
 
 [working-directory: 'examples-output']
 clean-all:
@@ -34,9 +39,11 @@ clean-all:
     rm -rf chunked-barrier.rfr
     rm -rf chunked-ping-pong.rfr
     rm -rf chunked-spawn.rfr
+    rm -rf chunked-thousand-tasks.rfr
     rm -f ping-pong-chunked.html
     rm -f ping-pong-stream.html
     rm -f recording-ping_pong-stream.rfr
     rm -f recording-spawn-stream.rfr
     rm -f spawn-chunked.html
     rm -f spawn-stream.html
+    rm -f thousand-tasks.html

--- a/rfr-subscriber/examples/thousand-tasks.rs
+++ b/rfr-subscriber/examples/thousand-tasks.rs
@@ -1,0 +1,44 @@
+use std::{future::Future, time::Duration};
+
+use rfr_subscriber::RfrChunkedLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let rfr_layer = RfrChunkedLayer::new("./chunked-thousand-tasks.rfr");
+    let flusher = rfr_layer.flusher();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let mut join_handles = Vec::new();
+        for idx in 0..1_000 {
+            let task_name = format!("task-{idx}");
+            join_handles.push(spawn_named(&task_name, async {
+                tokio::time::sleep(Duration::from_micros(100)).await;
+            }));
+        }
+
+        for jh in join_handles {
+            jh.await.unwrap();
+        }
+    });
+
+    flusher.flush();
+}
+
+#[track_caller]
+fn spawn_named<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}


### PR DESCRIPTION
Most of the instrumented examples (in the `rfr-subscriber` crate) have a
relatively small number of tasks. It would be useful to have a standard
example with a few more.

The `thousand-tasks` example has just that, 1000 spawned tasks (plus the
usual compliment of a block_on task and blocking tasks for blocking
workers).

Given the lack of optimization (or any sort of performance consideration
at all) it runs surprisingly well in the RFR Viz UI.