### PR TITLE
feat(viz): add zoom functionality to UI

### DIFF
--- a/rfr/src/rec.rs
+++ b/rfr/src/rec.rs
@@ -86,6 +86,10 @@ impl WinTimestamp {
     pub fn as_micros(&self) -> u64 {
         self.micros
     }
+
+    pub fn as_nanos(&self) -> u64 {
+        self.micros * 1_000
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
The first implementation of the Viz UI had a fixed scale of 1
microsecond per pixel. In reality, users will want to zoom in and out
and see the recording at different scales.

The user must also have a way to see the scale being represented.

This change adds a time bar above the task bars, which shows the time
from the beginning of the recording.

It also allows the user to zoom in (`+`/`=`) and zoom out (`=`) to see
the recording at different scales, which is reflected in the time bar
and the task bars themselves.

As part of this change, the base unit for the Viz UI has been changed
from microseconds to nanoseconds. However, the recordings still use
microsecond precision.