### PR TITLE
fix(viz): display final state of task

### DIFF
--- a/rfr-viz/src/gen.rs
+++ b/rfr-viz/src/gen.rs
@@ -75,6 +75,14 @@ fn write_viz(writer: impl io::Write, info: RecordingInfo, name: String) {
                     length = chart_time(section.duration),
                 ).unwrap();
             }
+            if let Some(state) = row.last_state {
+                let duration =
+                    info.end_time.as_micros() - (row.start_time.as_micros() + row.total_duration());
+                write!(out_fh,
+                    r#"<div title="{state}" class="task-state {state}" style="width: {length}px; max-width: {length}px;"></div>"#,
+                    length = chart_time(duration),
+                ).unwrap();
+            }
             writeln!(out_fh).unwrap();
         }
 


### PR DESCRIPTION
When a task is not dropped by the end of the recording, we were not
displaying a section for its final state. This was especially obvious in
Tokio's blocking workers, which show up as blocking tasks that become
active and then never change, however it will also affect any partial
recording, where it is likely that some tasks would still exist at the
end of the available recordering.

To solve this problem, the `TaskRow` struct had a new `final_state`
field, which optionally holds the last known state of the task. In the
Viz UI, we then create a section which extends until the end of
recording time with this state.

The Viz HTML generator was also updated to extend the last state as a
section to the end of the visualization.