### PR TITLE
fix(rfr): make `Event` fields public

### DIFF
--- a/rfr/src/common.rs
+++ b/rfr/src/common.rs
@@ -95,10 +95,10 @@ pub enum Parent {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct Event {
-    callsite_id: CallsiteId,
-    parent: Parent,
-    split_field_values: Vec<FieldValue>,
-    dynamic_fields: Vec<Field>,
+    pub callsite_id: CallsiteId,
+    pub parent: Parent,
+    pub split_field_values: Vec<FieldValue>,
+    pub dynamic_fields: Vec<Field>,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]


### PR DESCRIPTION
The fields of all the structs and enums that represent a recording
(streaming or chunked) should be public. This doesn't include the helper
reader and writer structs, just those that implement Serialize and
Deserialize.

This wasn't the case for the `Event` struct, where none of the fields
were marked `pub`.

This change fixes this and marks all fields `pub`.