### PR TITLE
chore: split examples from HTML gen in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,34 +2,64 @@ create-examples-output:
     mkdir -p examples-output
 
 [working-directory: 'examples-output']
-spawn-streamed: create-examples-output
+example-spawn-streamed: create-examples-output
     cargo run -p rfr-subscriber --example spawn
+
+[working-directory: 'examples-output']
+viz-gen-spawn-streamed: create-examples-output
     cargo run -p rfr-viz -- generate recording-spawn-stream.rfr --name spawn-stream
 
+spawn-streamed: example-spawn-streamed viz-gen-spawn-streamed
+
 [working-directory: 'examples-output']
-ping-pong-streamed: create-examples-output
+example-ping-pong-streamed: create-examples-output
     cargo run -p rfr-subscriber --example ping-pong
+
+[working-directory: 'examples-output']
+viz-gen-ping-pong-streamed: create-examples-output
     cargo run -p rfr-viz -- generate recording-ping_pong-stream.rfr --name ping-pong-stream
 
+ping-pong-streamed: example-spawn-streamed viz-gen-spawn-streamed
+
 [working-directory: 'examples-output']
-spawn-chunked: create-examples-output
+example-spawn-chunked: create-examples-output
     cargo run -p rfr-subscriber --example spawn-chunked
+
+[working-directory: 'examples-output']
+viz-gen-spawn-chunked: create-examples-output
     cargo run -p rfr-viz -- generate chunked-spawn.rfr --name spawn-chunked
 
-[working-directory: 'examples-output']
-ping-pong-chunked: create-examples-output
-    cargo run -p rfr-subscriber --example ping-pong-chunked
-    cargo run -p rfr-viz -- generate chunked-ping-pong.rfr --name ping-pong-chunked
+spawn-chunked: example-spawn-chunked viz-gen-spawn-chunked
 
 [working-directory: 'examples-output']
-barrier-chunked: create-examples-output
+example-ping-pong-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example ping-pong-chunked
+
+[working-directory: 'examples-output']
+viz-gen-ping-pong-chunked: create-examples-output
+    cargo run -p rfr-viz -- generate chunked-ping-pong.rfr --name ping-pong-chunked
+
+ping-pong-chunked: example-ping-pong-chunked viz-gen-ping-pong-chunked
+
+[working-directory: 'examples-output']
+example-barrier-chunked: create-examples-output
     cargo run -p rfr-subscriber --example barrier
-    cargo run -p rfr-viz -- generate chunked-barrier.rfr --name barrier
     
 [working-directory: 'examples-output']
-thousand-tasks-chunked: create-examples-output
+viz-gen-barrier-chunked: create-examples-output
+    cargo run -p rfr-viz -- generate chunked-barrier.rfr --name barrier
+    
+barrier-chunked: example-barrier-chunked viz-gen-barrier-chunked
+    
+[working-directory: 'examples-output']
+example-thousand-tasks-chunked: create-examples-output
     cargo run -p rfr-subscriber --example thousand-tasks
+
+[working-directory: 'examples-output']
+viz-gen-thousand-tasks-chunked: create-examples-output
     cargo run -p rfr-viz -- generate chunked-thousand-tasks.rfr --name thousand-tasks
+
+thousand-tasks-chunked: example-thousand-tasks-chunked viz-gen-thousand-tasks-chunked
 
 all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked thousand-tasks-chunked
 


### PR DESCRIPTION
With the new Viz UI, we often want to only run examples with `just`, and
not run `rfr-viz` to generate HTML (since we'll use the Viz UI instead).

This change splits all the targets in the `justfile` so that each
example can be run separately from the Viz HTML generation. The previous
targets that run the example and then generate the HTML directly still
exist, but now depend on the split targets to achieve that.