### PR TITLE
fix(rfr): return error when creating chunked recording that already exists

### DIFF
--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -76,7 +76,7 @@ impl RfrChunkedLayer {
     }
 
     fn spawn_writer(base_dir: String) -> WriterHandle {
-        let writer = Arc::new(ChunkedWriter::try_new(base_dir.to_owned()).unwrap());
+        let writer = Arc::new(ChunkedWriter::try_new(base_dir).unwrap());
 
         let thread_writer = Arc::clone(&writer);
         let join_handle = thread::Builder::new()


### PR DESCRIPTION
A chunked recording that actually contains data from multiple recordings
will create all sorts of problems when reading it. One basic way to help
avoid this situation is to not allow a `ChunkedWriter` to be created for
a directory that is already a recording.

This change adds checks when creating the root directory for the
recording as well as when creating the meta file for that recording,
since the meta file is written as part of `ChunkedWriter::try_new`. If
either of them exist, then an error will be returned.

Some of the error types for creating a callsites file have been
generalized to be used when writing the meta file too. The already
exists error is separate.

Note that we should really have a more robust way of ensuring the
coherence of a recording, but that is beyond the scope of this change.