### PR TITLE
feat(subscriber): add outside runtime example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,3 +125,9 @@ jobs:
 
       - name: Barrier (chunked)
         run: just barrier-chunked
+
+      - name: Thousand Tasks (chunked)
+        run: just thousand-tasks-chunked
+
+      - name: Outside runtime (chunked)
+        run: just outside-runtime-chunked

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /docs/book
+/examples-output

--- a/justfile
+++ b/justfile
@@ -71,7 +71,17 @@ viz-gen-long-chunked: create-examples-output
 
 long-chunked: example-long-chunked viz-gen-long-chunked
 
-all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked thousand-tasks-chunked long-chunked
+[working-directory: 'examples-output']
+example-outside-runtime-chunked: create-examples-output
+    cargo run -p rfr-subscriber --example outside-runtime
+
+[working-directory: 'examples-output']
+viz-gen-outside-runtime-chunked: create-examples-output
+    cargo run -p rfr-viz -- generate chunked-outside-runtime.rfr --name outside-runtime
+
+outside-runtime-chunked: example-outside-runtime-chunked viz-gen-outside-runtime-chunked
+
+all-examples: spawn-streamed ping-pong-streamed spawn-chunked ping-pong-chunked barrier-chunked thousand-tasks-chunked long-chunked outside-runtime-chunked
 
 [working-directory: 'examples-output']
 clean-all:
@@ -81,6 +91,7 @@ clean-all:
     rm -rf chunked-spawn.rfr
     rm -rf chunked-thousand-tasks.rfr
     rm -rf chunked-long.rfr
+    rm -rf chunked-outside-runtime.rfr
     rm -f ping-pong-chunked.html
     rm -f ping-pong-stream.html
     rm -f recording-ping_pong-stream.rfr
@@ -89,3 +100,4 @@ clean-all:
     rm -f spawn-stream.html
     rm -f thousand-tasks.html
     rm -f long.html
+    rm -f outside-runtime.html

--- a/rfr-subscriber/examples/outside-runtime.rs
+++ b/rfr-subscriber/examples/outside-runtime.rs
@@ -1,0 +1,95 @@
+use std::{future::Future, thread};
+
+use tokio::sync::mpsc;
+
+use rfr_subscriber::RfrChunkedLayer;
+use tracing_subscriber::prelude::*;
+
+fn main() {
+    let rfr_layer = RfrChunkedLayer::new("./chunked-outside-runtime.rfr");
+    let flusher = rfr_layer.flusher();
+    tracing_subscriber::registry().with(rfr_layer).init();
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let (up_tx, up_rx) = mpsc::channel::<()>(1);
+        let (dn_tx, dn_rx) = mpsc::channel::<()>(1);
+        let serve_dn_tx = dn_tx.clone();
+
+        let task_jh = spawn_task("ping", ping_pong_task(3, up_tx, dn_rx));
+        let thread_jh = spawn_thread("pong", || ping_pong_thread(3, dn_tx, up_rx));
+
+        // serve
+        serve_dn_tx.send(()).await.unwrap();
+
+        task_jh.await.unwrap();
+        thread_jh.join().unwrap();
+    });
+
+    flusher.wait_flush().unwrap();
+}
+
+async fn ping_pong_task(count: usize, tx: mpsc::Sender<()>, mut rx: mpsc::Receiver<()>) {
+    for _ in 0..count {
+        match rx.recv().await {
+            Some(_) => {
+                // received something!
+            }
+            None => break,
+        }
+
+        match tx.send(()).await {
+            Ok(_) => {
+                // sent something!
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+fn ping_pong_thread(count: usize, tx: mpsc::Sender<()>, mut rx: mpsc::Receiver<()>) {
+    for _ in 0..count {
+        match rx.blocking_recv() {
+            Some(_) => {
+                // received something!
+            }
+            None => break,
+        }
+
+        match tx.blocking_send(()) {
+            Ok(_) => {
+                // sent something!
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+#[track_caller]
+fn spawn_task<Fut>(name: &str, f: Fut) -> tokio::task::JoinHandle<<Fut as Future>::Output>
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    tokio::task::Builder::new()
+        .name(name)
+        .spawn(f)
+        .unwrap_or_else(|_| panic!("spawning task '{name}' failed"))
+}
+
+#[track_caller]
+fn spawn_thread<F, T>(name: &str, func: F) -> thread::JoinHandle<T>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    thread::Builder::new()
+        .name(name.into())
+        .spawn(func)
+        .unwrap_or_else(|_| panic!("sapwning thread '{name}' failed"))
+}


### PR DESCRIPTION
None of the current examples show tasks getting woken from outside the
Tokio runtime. It would be good to have such an example.

Adds a new example that is similar to the `ping-pong` example, but the
pong side is running in a system thread instead of a Tokio task. The
communication is still via a Tokio MPSC channel.

There is only a single `outside-runtime` example and it uses the chunked
recording format (no extra example using the streaming format).

Additionally, the `thousand-tasks` example was added to the CI as it had
been missed.