### PR TITLE
chore: update formatting to 2024 rules

### DIFF
--- a/rfr-convert/src/main.rs
+++ b/rfr-convert/src/main.rs
@@ -7,7 +7,7 @@ mod convert;
 mod generated;
 mod perfetto;
 
-use crate::convert::{convert, OutputFormat};
+use crate::convert::{OutputFormat, convert};
 
 #[derive(Parser)]
 #[command(about = "Convert rfr recordings to other trace formats", long_about = None)]

--- a/rfr-convert/src/perfetto.rs
+++ b/rfr-convert/src/perfetto.rs
@@ -9,8 +9,8 @@ use rfr::{
 use crate::{
     collect::{CollectedData, Data, DynamicId, SeqRecords, TaskRecords, WakeId, WakerAction},
     generated::{
-        track_descriptor, track_event, DebugAnnotation, ProcessDescriptor, Trace, TracePacket,
-        TrackDescriptor, TrackEvent,
+        DebugAnnotation, ProcessDescriptor, Trace, TracePacket, TrackDescriptor, TrackEvent,
+        track_descriptor, track_event,
     },
 };
 

--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -6,8 +6,8 @@ use std::{
     time::Duration,
 };
 
-use tracing::{span, subscriber::Interest, Event, Metadata, Subscriber};
-use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+use tracing::{Event, Metadata, Subscriber, span, subscriber::Interest};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
     chunked::{self, ChunkedWriter},
@@ -16,8 +16,8 @@ use rfr::{
 };
 
 use crate::subscriber::common::{
-    get_context_task_iid, to_callsite, to_callsite_id, to_iid, EventKind, SpanKind, SpawnFields,
-    SpawnSpan, TaskId, TaskKind, TraceKind, WakerFields, WakerOp,
+    EventKind, SpanKind, SpawnFields, SpawnSpan, TaskId, TaskKind, TraceKind, WakerFields, WakerOp,
+    get_context_task_iid, to_callsite, to_callsite_id, to_iid,
 };
 
 struct WriterHandle {

--- a/rfr-subscriber/src/subscriber/common.rs
+++ b/rfr-subscriber/src/subscriber/common.rs
@@ -5,8 +5,9 @@ use rfr::{
     common::{Field, FieldName, FieldValue, InstrumentationId},
 };
 use tracing::{
+    Level, Metadata, Subscriber,
     field::{self, Visit},
-    span, Level, Metadata, Subscriber,
+    span,
 };
 use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
@@ -57,7 +58,7 @@ impl TryFrom<&Metadata<'_>> for TraceKind {
                 _ => {
                     return Err(TryFromMetadataError {
                         desc: "span metadata isn't interesting",
-                    })
+                    });
                 }
             }
             .into())
@@ -70,7 +71,7 @@ impl TryFrom<&Metadata<'_>> for TraceKind {
                 _ => {
                     return Err(TryFromMetadataError {
                         desc: "event metadata isn't interesting",
-                    })
+                    });
                 }
             }
             .into())

--- a/rfr-subscriber/src/subscriber/layer.rs
+++ b/rfr-subscriber/src/subscriber/layer.rs
@@ -4,8 +4,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use tracing::{span, subscriber::Interest, Dispatch, Event, Metadata, Subscriber};
-use tracing_subscriber::{layer::Context, registry::LookupSpan, Layer};
+use tracing::{Dispatch, Event, Metadata, Subscriber, span, subscriber::Interest};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
     chunked::CallsiteId,
@@ -14,8 +14,8 @@ use rfr::{
 };
 
 use crate::subscriber::common::{
-    get_context_task_iid, to_callsite_id, to_iid, EventKind, SpanKind, SpawnFields, SpawnSpan,
-    TaskId, TaskKind, TraceKind, WakerFields, WakerOp,
+    EventKind, SpanKind, SpawnFields, SpawnSpan, TaskId, TaskKind, TraceKind, WakerFields, WakerOp,
+    get_context_task_iid, to_callsite_id, to_iid,
 };
 
 pub struct RfrLayer {

--- a/rfr-viz/src/collect.rs
+++ b/rfr-viz/src/collect.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, convert::identity, fmt, ops::Add, time::Duration
 use rfr::{
     chunked::{self, RecordData},
     common::{InstrumentationId, Task},
-    rec::{self, from_file, AbsTimestamp, WinTimestamp},
+    rec::{self, AbsTimestamp, WinTimestamp, from_file},
 };
 
 pub(crate) struct WinTimeHandle {
@@ -25,7 +25,10 @@ impl WinTimeHandle {
         let start_time = duration_from_abs_timestamp(&self.start_time);
         let duration = Duration::new(abs_time.secs, abs_time.subsec_micros * 1000);
         let window_micros = duration.saturating_sub(start_time).as_micros();
-        debug_assert!(window_micros < u64::MAX as u128, "recording time spans more than u64::MAX microseconds, which is more than 500 thousand years");
+        debug_assert!(
+            window_micros < u64::MAX as u128,
+            "recording time spans more than u64::MAX microseconds, which is more than 500 thousand years"
+        );
 
         rec::WinTimestamp {
             micros: window_micros as u64,

--- a/rfr-viz/src/generate.rs
+++ b/rfr-viz/src/generate.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fs, io};
 use rfr::common::TaskKind;
 
 use crate::collect::{
-    self, chunked_recording_info, streaming_recording_info, RecordingInfo, SpawnRecordKind,
+    self, RecordingInfo, SpawnRecordKind, chunked_recording_info, streaming_recording_info,
 };
 
 pub(crate) fn generate_html(recording_file: String, name: String) {

--- a/rfr-viz/src/ui.rs
+++ b/rfr-viz/src/ui.rs
@@ -5,8 +5,8 @@ use egui_extras::StripBuilder;
 use rfr::{common::TaskKind, rec};
 
 use crate::collect::{
-    chunked_recording_info, streaming_recording_info, RecordingInfo, SpawnRecordKind, TaskIndex,
-    TaskRow, TaskSection, TaskState, WakeRecordKind,
+    RecordingInfo, SpawnRecordKind, TaskIndex, TaskRow, TaskSection, TaskState, WakeRecordKind,
+    chunked_recording_info, streaming_recording_info,
 };
 
 static TASK_ROW_HEIGHT: f32 = 42.;

--- a/rfr/src/chunked/meta.rs
+++ b/rfr/src/chunked/meta.rs
@@ -8,7 +8,7 @@ use std::io;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{identifier::ReadFormatIdentifierError, rec, FormatIdentifier, FormatVariant};
+use crate::{FormatIdentifier, FormatVariant, identifier::ReadFormatIdentifierError, rec};
 
 /// The format identifier for the Meta file
 pub fn version() -> FormatIdentifier {

--- a/rfr/src/chunked/mod.rs
+++ b/rfr/src/chunked/mod.rs
@@ -4,20 +4,20 @@ use std::{
     io::{self, SeekFrom},
     path::{Path, PathBuf},
     sync::{
-        atomic::{self, AtomicBool},
         Arc, Condvar, Mutex,
+        atomic::{self, AtomicBool},
     },
     time::{Duration, Instant},
 };
 
-use jiff::{tz::TimeZone, Timestamp, Zoned};
+use jiff::{Timestamp, Zoned, tz::TimeZone};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 
 use crate::{
+    FormatIdentifier, FormatVariant,
     common::{Span, Task},
     rec::{self, AbsTimestamp},
-    FormatIdentifier, FormatVariant,
 };
 
 mod callsite;
@@ -780,7 +780,9 @@ impl Chunk {
                         }
                         buffer.resize(new_size * 2, 0);
                         if let Err(err) = reader.seek(SeekFrom::Start(file_pos)) {
-                            println!("Could not seek back to start of element after making buffer bigger: {err}");
+                            println!(
+                                "Could not seek back to start of element after making buffer bigger: {err}"
+                            );
                             file_buffer = (&mut reader, buffer.as_mut_slice());
                             continue 'seq_chunk;
                         }
@@ -797,7 +799,7 @@ impl Chunk {
             };
 
             seq_chunks.push(seq_chunk_result.0);
-            file_buffer = (seq_chunk_result.1 .0, buffer.as_mut_slice());
+            file_buffer = (seq_chunk_result.1.0, buffer.as_mut_slice());
         }
 
         Ok(Self { header, seq_chunks })

--- a/rfr/src/chunked/sequence.rs
+++ b/rfr/src/chunked/sequence.rs
@@ -12,8 +12,8 @@ use std::{
     collections::{HashMap, HashSet},
     io,
     sync::{
-        atomic::{AtomicU64, Ordering},
         Mutex,
+        atomic::{AtomicU64, Ordering},
     },
 };
 

--- a/rfr/src/identifier.rs
+++ b/rfr/src/identifier.rs
@@ -1,6 +1,6 @@
 use std::{fmt, io, str::FromStr};
 
-use serde::{de::Visitor, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Visitor};
 
 /// Represents the RFR format variant used to encode a file.
 ///

--- a/rfr/src/rec.rs
+++ b/rfr/src/rec.rs
@@ -8,9 +8,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    FormatIdentifier, FormatVariant,
     chunked::Callsite,
     common::{Event, InstrumentationId, Span, Task, Waker},
-    FormatIdentifier, FormatVariant,
 };
 
 fn current_software_version() -> FormatIdentifier {
@@ -250,7 +250,9 @@ pub fn from_file(filename: String) -> Vec<Record> {
                     }
                     buffer_vec.resize(new_size * 2, 0);
                     if let Err(err) = file.seek(SeekFrom::Start(file_pos)) {
-                        println!("Could not seek back to start of element after making buffer bigger: {err}");
+                        println!(
+                            "Could not seek back to start of element after making buffer bigger: {err}"
+                        );
                         file_buffer = (&mut file, &mut buffer_vec as &mut [u8]);
                         continue 'record;
                     }
@@ -265,7 +267,7 @@ pub fn from_file(filename: String) -> Vec<Record> {
         };
 
         records.push(result.0);
-        file_buffer = (result.1 .0, &mut buffer_vec as &mut [u8]);
+        file_buffer = (result.1.0, &mut buffer_vec as &mut [u8]);
     }
 
     records

--- a/rfr/tests/chunked_writer.rs
+++ b/rfr/tests/chunked_writer.rs
@@ -2,8 +2,8 @@ use std::{fs, sync::Arc, thread, time::Duration};
 
 use rfr::{
     chunked::{
-        self, from_path, Callsite, CallsiteId, ChunkedWriter, Meta, NewChunkedWriterError, Record,
-        RecordData,
+        self, Callsite, CallsiteId, ChunkedWriter, Meta, NewChunkedWriterError, Record, RecordData,
+        from_path,
     },
     common::{Event, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent},
     rec::AbsTimestamp,
@@ -116,7 +116,9 @@ fn directory_already_exists() {
 
     match result.unwrap_err() {
         NewChunkedWriterError::AlreadyExists => {} // expected result
-        other_err => panic!("expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"),
+        other_err => panic!(
+            "expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"
+        ),
     }
 }
 
@@ -136,6 +138,8 @@ fn meta_already_exists() {
 
     match result.unwrap_err() {
         NewChunkedWriterError::AlreadyExists => {} // expected result
-        other_err => panic!("expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"),
+        other_err => panic!(
+            "expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"
+        ),
     }
 }

--- a/rfr/tests/meta.rs
+++ b/rfr/tests/meta.rs
@@ -1,8 +1,8 @@
 // TODO(hds): Write tests for meta file handling
 use rfr::{
+    FormatIdentifier, FormatVariant,
     chunked::{ChunkedMeta, ChunkedMetaHeader, MetaTryFromIoError},
     rec::AbsTimestamp,
-    FormatIdentifier, FormatVariant,
 };
 
 #[test]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,0 @@
-style_edition = "2021"


### PR DESCRIPTION
In the previous change (#34), the Rust edition was updated to 2024,
however the formatting rules were kept on 2021 in order to reduce the
size of the change.

This change removes the `rustfmt.toml` file leaving the default
formatting rules (which are 2024 since the edition was already updated
on all the crates).