### PR TITLE
refac(rfr): make common module private

### DIFF
--- a/rfr-convert/src/collect.rs
+++ b/rfr-convert/src/collect.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, convert::identity};
 
 use rfr::{
-    AbsTimestamp,
+    AbsTimestamp, InstrumentationId, Task, Waker,
     chunked::{self, RecordData, SeqChunkHeader, SeqId},
-    common::{InstrumentationId, Task, Waker},
 };
 
 /// Data collected for conversion

--- a/rfr-convert/src/perfetto.rs
+++ b/rfr-convert/src/perfetto.rs
@@ -1,10 +1,7 @@
 use std::{fmt, fs, io::Write, mem};
 
 use prost::Message;
-use rfr::{
-    AbsTimestamp,
-    common::{TaskKind, Waker},
-};
+use rfr::{AbsTimestamp, TaskKind, Waker};
 
 use crate::{
     collect::{CollectedData, Data, DynamicId, SeqRecords, TaskRecords, WakeId, WakerAction},

--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -10,9 +10,8 @@ use tracing::{Event, Metadata, Subscriber, span, subscriber::Interest};
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
-    AbsTimestamp,
+    AbsTimestamp, InstrumentationId,
     chunked::{self, ChunkedWriter},
-    common::{self, InstrumentationId},
 };
 
 use crate::subscriber::common::{
@@ -212,18 +211,18 @@ where
                     extensions.insert(spawn.task_id);
                 }
                 {
-                    let task_id = common::TaskId::from(spawn.task_id.0);
-                    let task = chunked::Object::Task(common::Task {
+                    let task_id = rfr::TaskId::from(spawn.task_id.0);
+                    let task = chunked::Object::Task(rfr::Task {
                         iid: spawn.iid,
                         callsite_id: spawn.callsite_id,
                         task_id,
                         task_name: spawn.task_name,
                         task_kind: match spawn.task_kind {
-                            TaskKind::Task => common::TaskKind::Task,
-                            TaskKind::Local => common::TaskKind::Local,
-                            TaskKind::Blocking => common::TaskKind::Blocking,
-                            TaskKind::BlockOn => common::TaskKind::BlockOn,
-                            TaskKind::Other(val) => common::TaskKind::Other(val),
+                            TaskKind::Task => rfr::TaskKind::Task,
+                            TaskKind::Local => rfr::TaskKind::Local,
+                            TaskKind::Blocking => rfr::TaskKind::Blocking,
+                            TaskKind::BlockOn => rfr::TaskKind::BlockOn,
+                            TaskKind::Other(val) => rfr::TaskKind::Other(val),
                         },
 
                         context: spawn.context,
@@ -260,7 +259,7 @@ where
                 let task_span_id = fields.task_span_id.unwrap();
 
                 {
-                    let waker = common::Waker {
+                    let waker = rfr::Waker {
                         task_iid: to_iid(&task_span_id),
                         context: ctx.current_span().id().map(to_iid),
                     };

--- a/rfr-subscriber/src/subscriber/common.rs
+++ b/rfr-subscriber/src/subscriber/common.rs
@@ -1,8 +1,8 @@
 use std::{error, fmt, ptr};
 
 use rfr::{
+    Field, FieldName, FieldValue, InstrumentationId,
     chunked::{Callsite, CallsiteId},
-    common::{Field, FieldName, FieldValue, InstrumentationId},
 };
 use tracing::{
     Level, Metadata, Subscriber,
@@ -130,7 +130,7 @@ pub(super) fn to_callsite(metadata: &Metadata<'_>) -> Callsite {
     }
     Callsite {
         callsite_id: to_callsite_id(metadata),
-        level: rfr::common::Level(match *metadata.level() {
+        level: rfr::Level(match *metadata.level() {
             Level::ERROR => 50,
             Level::WARN => 40,
             Level::INFO => 30,
@@ -138,9 +138,9 @@ pub(super) fn to_callsite(metadata: &Metadata<'_>) -> Callsite {
             Level::TRACE => 10,
         }),
         kind: if metadata.is_span() {
-            rfr::common::Kind::Span
+            rfr::Kind::Span
         } else {
-            rfr::common::Kind::Event
+            rfr::Kind::Event
         },
         const_fields,
         split_field_names,

--- a/rfr-subscriber/src/subscriber/layer.rs
+++ b/rfr-subscriber/src/subscriber/layer.rs
@@ -9,7 +9,6 @@ use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
     chunked::CallsiteId,
-    common,
     streamed::{Meta, Record, RecordData, StreamWriter},
 };
 
@@ -112,19 +111,19 @@ where
                 }
                 {
                     let mut guard = self.writer.lock().unwrap();
-                    let task_id = common::TaskId::from(spawn.task_id.0);
+                    let task_id = rfr::TaskId::from(spawn.task_id.0);
                     let task_data = RecordData::Task {
-                        task: common::Task {
+                        task: rfr::Task {
                             iid: spawn.iid,
                             callsite_id: spawn.callsite_id,
                             task_id,
                             task_name: spawn.task_name,
                             task_kind: match spawn.task_kind {
-                                TaskKind::Task => common::TaskKind::Task,
-                                TaskKind::Local => common::TaskKind::Local,
-                                TaskKind::Blocking => common::TaskKind::Blocking,
-                                TaskKind::BlockOn => common::TaskKind::BlockOn,
-                                TaskKind::Other(val) => common::TaskKind::Other(val),
+                                TaskKind::Task => rfr::TaskKind::Task,
+                                TaskKind::Local => rfr::TaskKind::Local,
+                                TaskKind::Blocking => rfr::TaskKind::Blocking,
+                                TaskKind::BlockOn => rfr::TaskKind::BlockOn,
+                                TaskKind::Other(val) => rfr::TaskKind::Other(val),
                             },
 
                             context: spawn.context,
@@ -163,7 +162,7 @@ where
                 let task_span_id = fields.task_span_id.unwrap();
 
                 let mut guard = self.writer.lock().unwrap();
-                let waker = common::Waker {
+                let waker = rfr::Waker {
                     task_iid: to_iid(&task_span_id),
                     context: ctx.current_span().id().map(to_iid),
                 };

--- a/rfr-viz/src/collect.rs
+++ b/rfr-viz/src/collect.rs
@@ -1,9 +1,8 @@
 use std::{collections::HashMap, convert::identity, fmt, ops::Add, time::Duration};
 
 use rfr::{
-    AbsTimestamp,
+    AbsTimestamp, InstrumentationId, Task,
     chunked::{self, RecordData},
-    common::{InstrumentationId, Task},
     streamed,
 };
 

--- a/rfr-viz/src/generate.rs
+++ b/rfr-viz/src/generate.rs
@@ -1,6 +1,6 @@
 use std::{cmp::Ordering, fs, io};
 
-use rfr::common::TaskKind;
+use rfr::TaskKind;
 
 use crate::collect::{
     self, RecordingInfo, SpawnRecordKind, chunked_recording_info, streaming_recording_info,

--- a/rfr-viz/src/ui.rs
+++ b/rfr-viz/src/ui.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fs};
 
 use eframe::{egui, epaint};
 use egui_extras::StripBuilder;
-use rfr::common::TaskKind;
+use rfr::TaskKind;
 
 use crate::collect::{
     RecordingInfo, SpawnRecordKind, TaskIndex, TaskRow, TaskSection, TaskState, WakeRecordKind,

--- a/rfr/src/lib.rs
+++ b/rfr/src/lib.rs
@@ -1,7 +1,10 @@
 pub mod chunked;
-pub mod common;
+mod common;
 mod identifier;
 pub mod streamed;
 
-pub use common::AbsTimestamp;
+pub use common::{
+    AbsTimestamp, Event, Field, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent,
+    Span, Task, TaskId, TaskKind, Waker,
+};
 pub use identifier::{FormatIdentifier, FormatVariant, ParseFormatVersionError};

--- a/rfr/tests/callsite.rs
+++ b/rfr/tests/callsite.rs
@@ -1,6 +1,6 @@
 use rfr::{
+    Kind, Level,
     chunked::{Callsite, CallsiteId, ChunkedCallsites, ChunkedCallsitesWriter},
-    common::{Kind, Level},
 };
 
 #[test]

--- a/rfr/tests/chunked_sequence.rs
+++ b/rfr/tests/chunked_sequence.rs
@@ -1,9 +1,8 @@
 use rfr::{
-    AbsTimestamp,
+    AbsTimestamp, InstrumentationId, Task, TaskKind,
     chunked::{
         CallsiteId, ChunkInterval, Meta, Object, Record, RecordData, SeqChunk, SeqChunkBuffer,
     },
-    common::{InstrumentationId, Task, TaskKind},
 };
 
 #[test]

--- a/rfr/tests/chunked_writer.rs
+++ b/rfr/tests/chunked_writer.rs
@@ -1,12 +1,11 @@
 use std::{fs, sync::Arc, thread, time::Duration};
 
 use rfr::{
-    AbsTimestamp,
+    AbsTimestamp, Event, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent,
     chunked::{
         self, Callsite, CallsiteId, ChunkedWriter, Meta, NewChunkedWriterError, Record, RecordData,
         from_path,
     },
-    common::{Event, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent},
 };
 use tempfile::tempdir;
 


### PR DESCRIPTION
I never really liked having types in a "common" module exposed that way
outside the `rfr` crate.

This change follows the same pattern for the `common` module as had
already been done with the `identifier` module. Keep the module private
and re-export the public types in the root of the `rfr` crate.

With `rfr` being a short name, it's easy enough to reference types
including the crate name (this is done in `rfr-subscriber` for example,
where plenty of types have naming conflicts).