### PR TITLE
refac(rfr): move `Callsite` and `CallsiteId` out of `chunked` module

### DIFF
--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -10,7 +10,7 @@ use tracing::{Event, Metadata, Subscriber, span, subscriber::Interest};
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
-    AbsTimestamp, InstrumentationId,
+    AbsTimestamp, Callsite, CallsiteId, InstrumentationId,
     chunked::{self, ChunkedWriter},
 };
 
@@ -59,7 +59,7 @@ impl error::Error for FlushError {}
 
 pub struct RfrChunkedLayer {
     writer_handle: WriterHandle,
-    callsite_cache: Mutex<HashMap<chunked::CallsiteId, (chunked::Callsite, TraceKind)>>,
+    callsite_cache: Mutex<HashMap<CallsiteId, (Callsite, TraceKind)>>,
     object_cache: Mutex<HashMap<InstrumentationId, chunked::Object>>,
 }
 

--- a/rfr-subscriber/src/subscriber/common.rs
+++ b/rfr-subscriber/src/subscriber/common.rs
@@ -1,9 +1,6 @@
 use std::{error, fmt, ptr};
 
-use rfr::{
-    Field, FieldName, FieldValue, InstrumentationId,
-    chunked::{Callsite, CallsiteId},
-};
+use rfr::{Callsite, CallsiteId, Field, FieldName, FieldValue, InstrumentationId};
 use tracing::{
     Level, Metadata, Subscriber,
     field::{self, Visit},

--- a/rfr-subscriber/src/subscriber/layer.rs
+++ b/rfr-subscriber/src/subscriber/layer.rs
@@ -8,7 +8,7 @@ use tracing::{Dispatch, Event, Metadata, Subscriber, span, subscriber::Interest}
 use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
 
 use rfr::{
-    chunked::CallsiteId,
+    CallsiteId,
     streamed::{Meta, Record, RecordData, StreamWriter},
 };
 

--- a/rfr/src/callsite.rs
+++ b/rfr/src/callsite.rs
@@ -1,0 +1,38 @@
+//! A callsite is the place where instrumentation is emitted from.
+//!
+//! Callsite information is static for a process and can be stored only once for each callsite.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Field, FieldName, Kind, Level};
+
+/// An instrumented location in an application
+///
+/// A callsite contains all the const data for a specific location in the application where
+/// instrumentation is emitted from.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct Callsite {
+    pub callsite_id: CallsiteId,
+    pub level: Level,
+    pub kind: Kind,
+    pub const_fields: Vec<Field>,
+    pub split_field_names: Vec<FieldName>,
+}
+
+/// The callsite Id defines a unique callsite.
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
+pub struct CallsiteId(u64);
+
+impl From<u64> for CallsiteId {
+    /// Create a CallsiteId from a `u64` value.
+    fn from(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+impl CallsiteId {
+    /// The `u64` representation of the callsite Id.
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}

--- a/rfr/src/chunked/callsite.rs
+++ b/rfr/src/chunked/callsite.rs
@@ -6,11 +6,9 @@
 
 use std::{error, fmt, io};
 
-use serde::{Deserialize, Serialize};
-
 use crate::{
+    Callsite,
     chunked::WriteError,
-    common::{Field, FieldName, Kind, Level},
     identifier::{FormatIdentifier, FormatVariant, ReadFormatIdentifierError},
 };
 
@@ -21,37 +19,6 @@ pub fn version() -> FormatIdentifier {
         major: 0,
         minor: 0,
         patch: 1,
-    }
-}
-
-/// An instrumented location in an application
-///
-/// A callsite contains all the const data for a specific location in the application where
-/// instrumentation is emitted from.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-pub struct Callsite {
-    pub callsite_id: CallsiteId,
-    pub level: Level,
-    pub kind: Kind,
-    pub const_fields: Vec<Field>,
-    pub split_field_names: Vec<FieldName>,
-}
-
-/// The callsite Id defines a unique callsite.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
-pub struct CallsiteId(u64);
-
-impl From<u64> for CallsiteId {
-    /// Create a CallsiteId from a `u64` value.
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
-impl CallsiteId {
-    /// The `u64` representation of the callsite Id.
-    pub fn as_u64(&self) -> u64 {
-        self.0
     }
 }
 

--- a/rfr/src/chunked/mod.rs
+++ b/rfr/src/chunked/mod.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    AbsTimestamp, FormatIdentifier, FormatVariant,
-    common::{Span, Task},
-};
+use crate::{AbsTimestamp, FormatIdentifier, FormatVariant, Span, Task};
 
 mod callsite;
 mod meta;
@@ -12,9 +9,7 @@ mod record;
 mod sequence;
 mod write;
 
-pub use callsite::{
-    Callsite, CallsiteId, ChunkedCallsites, ChunkedCallsitesWriter, FlushCallsitesError,
-};
+pub use callsite::{ChunkedCallsites, ChunkedCallsitesWriter, FlushCallsitesError};
 pub use meta::{ChunkedMeta, ChunkedMetaHeader, MetaTryFromIoError};
 pub use read::{Recording, from_path};
 pub use record::{Meta, Record, RecordData};

--- a/rfr/src/chunked/record.rs
+++ b/rfr/src/chunked/record.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    chunked::ChunkTimestamp,
-    common::{Event, InstrumentationId, Waker},
-};
+use crate::{Event, InstrumentationId, Waker, chunked::ChunkTimestamp};
 
 /// A record containing timing metadata and record data.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/rfr/src/chunked/sequence.rs
+++ b/rfr/src/chunked/sequence.rs
@@ -20,9 +20,8 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AbsTimestamp,
+    AbsTimestamp, InstrumentationId,
     chunked::{AbsTimestampSecs, ChunkInterval, ChunkTimestamp, Object, Record, RecordData},
-    common::InstrumentationId,
 };
 
 /// Sequence chunk

--- a/rfr/src/chunked/write.rs
+++ b/rfr/src/chunked/write.rs
@@ -15,8 +15,8 @@ use crate::chunked::{
     AbsTimestampSecs, ChunkedCallsitesWriter, ChunkedMeta, current_software_version,
 };
 use crate::{
-    AbsTimestamp,
-    chunked::{Callsite, ChunkHeader, ChunkInterval, SeqChunkBuffer},
+    AbsTimestamp, Callsite,
+    chunked::{ChunkHeader, ChunkInterval, SeqChunkBuffer},
 };
 
 #[derive(Debug)]

--- a/rfr/src/common.rs
+++ b/rfr/src/common.rs
@@ -5,7 +5,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::chunked::CallsiteId;
+use crate::CallsiteId;
 
 /// A timestamp measured from the [`UNIX_EPOCH`].
 ///

--- a/rfr/src/lib.rs
+++ b/rfr/src/lib.rs
@@ -1,8 +1,10 @@
+mod callsite;
 pub mod chunked;
 mod common;
 mod identifier;
 pub mod streamed;
 
+pub use callsite::{Callsite, CallsiteId};
 pub use common::{
     AbsTimestamp, Event, Field, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent,
     Span, Task, TaskId, TaskKind, Waker,

--- a/rfr/src/streamed/mod.rs
+++ b/rfr/src/streamed/mod.rs
@@ -1,9 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AbsTimestamp, FormatIdentifier, FormatVariant,
-    chunked::Callsite,
-    common::{Event, InstrumentationId, Span, Task, Waker},
+    AbsTimestamp, Callsite, Event, FormatIdentifier, FormatVariant, InstrumentationId, Span, Task,
+    Waker,
 };
 
 mod read;

--- a/rfr/tests/callsite.rs
+++ b/rfr/tests/callsite.rs
@@ -1,6 +1,6 @@
 use rfr::{
-    Kind, Level,
-    chunked::{Callsite, CallsiteId, ChunkedCallsites, ChunkedCallsitesWriter},
+    Callsite, CallsiteId, Kind, Level,
+    chunked::{ChunkedCallsites, ChunkedCallsitesWriter},
 };
 
 #[test]

--- a/rfr/tests/chunked_sequence.rs
+++ b/rfr/tests/chunked_sequence.rs
@@ -1,8 +1,6 @@
 use rfr::{
-    AbsTimestamp, InstrumentationId, Task, TaskKind,
-    chunked::{
-        CallsiteId, ChunkInterval, Meta, Object, Record, RecordData, SeqChunk, SeqChunkBuffer,
-    },
+    AbsTimestamp, CallsiteId, InstrumentationId, Task, TaskKind,
+    chunked::{ChunkInterval, Meta, Object, Record, RecordData, SeqChunk, SeqChunkBuffer},
 };
 
 #[test]

--- a/rfr/tests/chunked_writer.rs
+++ b/rfr/tests/chunked_writer.rs
@@ -1,11 +1,9 @@
 use std::{fs, sync::Arc, thread, time::Duration};
 
 use rfr::{
-    AbsTimestamp, Event, FieldName, FieldValue, InstrumentationId, Kind, Level, Parent,
-    chunked::{
-        self, Callsite, CallsiteId, ChunkedWriter, Meta, NewChunkedWriterError, Record, RecordData,
-        from_path,
-    },
+    AbsTimestamp, Callsite, CallsiteId, Event, FieldName, FieldValue, InstrumentationId, Kind,
+    Level, Parent,
+    chunked::{self, ChunkedWriter, Meta, NewChunkedWriterError, Record, RecordData, from_path},
 };
 use tempfile::tempdir;
 


### PR DESCRIPTION
The callsite and its Id were originally created in the chunked module,
even though they are used in both chunked and streamed recording
formats. This is a bit confusing.

This change moves `Callsite` and `CallsiteId` to a new `callsite` module
in the root of the `rfr` crate and then exposes them at the root of the
crate (similar to what we do for all other public types that aren't in
the `chunked` or `streamed` modules.

Additionally, a few places where common types were still being referred
to within the `rfr` crate via the `common` module have been modified to
refer to the types at the root of the crate.