### PR TITLE
feat(subscriber): expose storage quota in chunked subscriber

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2839,6 +2839,7 @@ name = "rfr-subscriber"
 version = "0.1.0"
 dependencies = [
  "rfr",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/rfr-subscriber/Cargo.toml
+++ b/rfr-subscriber/Cargo.toml
@@ -11,4 +11,5 @@ tracing-subscriber = { version = "0.3", features = [] }
 rfr = { version = "0.0.1", path = "../rfr" }
 
 [dev-dependencies]
+tempfile = "3"
 tokio = { version = "1.38", features = ["full", "tracing"] }

--- a/rfr-subscriber/examples/barrier.rs
+++ b/rfr-subscriber/examples/barrier.rs
@@ -3,10 +3,10 @@ use std::{future::Future, sync::Arc, time::Duration};
 use tokio::sync::Barrier;
 use tracing_subscriber::prelude::*;
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-barrier.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-barrier.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/examples/long.rs
+++ b/rfr-subscriber/examples/long.rs
@@ -2,10 +2,10 @@ use std::{future::Future, task::Poll, time::Duration};
 
 use tracing_subscriber::prelude::*;
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-long.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-long.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/examples/outside-runtime.rs
+++ b/rfr-subscriber/examples/outside-runtime.rs
@@ -2,11 +2,11 @@ use std::{future::Future, thread};
 
 use tokio::sync::mpsc;
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 use tracing_subscriber::prelude::*;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-outside-runtime.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-outside-runtime.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/examples/ping-pong-chunked.rs
+++ b/rfr-subscriber/examples/ping-pong-chunked.rs
@@ -2,11 +2,11 @@ use std::future::Future;
 
 use tokio::sync::mpsc;
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 use tracing_subscriber::prelude::*;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-ping-pong.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-ping-pong.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/examples/spawn-chunked.rs
+++ b/rfr-subscriber/examples/spawn-chunked.rs
@@ -1,10 +1,10 @@
 use std::{future::Future, time::Duration};
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 use tracing_subscriber::prelude::*;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-spawn.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-spawn.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/examples/thousand-tasks.rs
+++ b/rfr-subscriber/examples/thousand-tasks.rs
@@ -1,10 +1,10 @@
 use std::{future::Future, time::Duration};
 
-use rfr_subscriber::RfrChunkedLayer;
+use rfr_subscriber::ChunkedLayer;
 use tracing_subscriber::prelude::*;
 
 fn main() {
-    let rfr_layer = RfrChunkedLayer::new("./chunked-thousand-tasks.rfr");
+    let rfr_layer = ChunkedLayer::new("./chunked-thousand-tasks.rfr");
     let flusher = rfr_layer.flusher();
     tracing_subscriber::registry().with(rfr_layer).init();
 

--- a/rfr-subscriber/src/lib.rs
+++ b/rfr-subscriber/src/lib.rs
@@ -1,4 +1,6 @@
 mod subscriber;
 
-pub use subscriber::RfrChunkedLayer;
 pub use subscriber::RfrLayer;
+pub use subscriber::{
+    ChunkedLayer, ChunkedLayerBuildError, ChunkedLayerBuilder, FlushError, Flusher, StorageQuota,
+};

--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -1,9 +1,8 @@
 use std::{
     collections::HashMap,
-    error, fmt,
+    error, fmt, io, process,
     sync::{Arc, Mutex},
-    thread::{self, JoinHandle},
-    time::Duration,
+    thread, time,
 };
 
 use tracing::{Event, Metadata, Subscriber, span, subscriber::Interest};
@@ -14,6 +13,8 @@ use rfr::{
     chunked::{self, ChunkedWriter},
 };
 
+pub use rfr::chunked::StorageQuota;
+
 use crate::subscriber::common::{
     EventKind, SpanKind, SpawnFields, SpawnSpan, TaskId, TaskKind, TraceKind, WakerFields, WakerOp,
     get_context_task_iid, to_callsite, to_callsite_id, to_iid,
@@ -21,9 +22,13 @@ use crate::subscriber::common::{
 
 struct WriterHandle {
     writer: Arc<ChunkedWriter>,
-    join_handle: Mutex<Option<JoinHandle<()>>>,
+    // TODO(hds): Is there actually ever a case where we need this? It feels wrong to throw away
+    // the join handle...
+    #[expect(unused)]
+    join_handle: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
+/// A flusher which can wait until the last written traces have be written to out before returning.
 pub struct Flusher {
     writer: Arc<ChunkedWriter>,
 }
@@ -36,7 +41,7 @@ impl Flusher {
     /// before returning.
     pub fn wait_flush(&self) -> Result<(), FlushError> {
         self.writer
-            .wait_for_write_timeout(Duration::from_micros(
+            .wait_for_write_timeout(time::Duration::from_micros(
                 self.writer.chunk_period_micros() as u64 * 2,
             ))
             .map_err(|inner| FlushError { inner })
@@ -57,59 +62,150 @@ impl fmt::Display for FlushError {
 
 impl error::Error for FlushError {}
 
-pub struct RfrChunkedLayer {
+/// A builder for the [`ChunkedLayer`].
+#[derive(Debug, Default)]
+pub struct ChunkedLayerBuilder {
+    recording_dir: Option<String>,
+    storage_quota: Option<StorageQuota>,
+}
+
+impl ChunkedLayerBuilder {
+    /// Set the base directory for the chunked recording.
+    ///
+    /// This is typically a directory with a `.rfr` extension.
+    ///
+    /// The default value is `{pid}.rfr` where `pid` is the current process's ID (PID).
+    pub fn recording_dir(self, base_dir: String) -> Self {
+        Self {
+            recording_dir: Some(base_dir),
+            ..self
+        }
+    }
+
+    /// Sets the storage quota for the chunked recording.
+    ///
+    /// If this value is not specified, the [`ChunkedWriter`] will determine the quota.
+    pub fn storage_quota(self, storage_quota: StorageQuota) -> Self {
+        Self {
+            storage_quota: Some(storage_quota),
+            ..self
+        }
+    }
+
+    /// Consumes the builder and returns an instantiated and running [`ChunkedLayer`] or an error
+    /// if the layer could not be constructed.
+    pub fn build(self) -> Result<ChunkedLayer, ChunkedLayerBuildError> {
+        let base_dir = self
+            .recording_dir
+            .unwrap_or_else(|| format!("./{pid}.rfr", pid = process::id()));
+
+        let writer = match self.storage_quota {
+            Some(storage_quota) => ChunkedWriter::try_new_with_config(base_dir, storage_quota),
+            None => ChunkedWriter::try_new(base_dir),
+        }
+        .map_err(|err| ChunkedLayerBuildError::NewChunkedWriterFailed { inner: err })?;
+
+        ChunkedLayer::new_with_writer(writer)
+            .map_err(|inner| ChunkedLayerBuildError::SpawnWriterThreadFailed { inner })
+    }
+}
+
+#[derive(Debug)]
+/// An error returned when a [`ChunkedLayer]` cannot be built.
+pub enum ChunkedLayerBuildError {
+    /// The [`ChunkedWriter`] could not be created.
+    NewChunkedWriterFailed {
+        inner: chunked::NewChunkedWriterError,
+    },
+    /// The writer thread which handles writing out recording chunks could not be spawned.
+    SpawnWriterThreadFailed { inner: io::Error },
+}
+
+impl fmt::Display for ChunkedLayerBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ChunkedLayerBuildError::NewChunkedWriterFailed { inner } => write!(
+                f,
+                "Chunked layer could not be built because a new chunked writer could not be created: {inner}"
+            ),
+            ChunkedLayerBuildError::SpawnWriterThreadFailed { inner } => write!(
+                f,
+                "Chunked layer could not be built because the chunk writer thread could not be spawned: {inner}"
+            ),
+        }
+    }
+}
+
+impl error::Error for ChunkedLayerBuildError {}
+
+/// A [`tracing`] layer that will write a chunked flight recording.
+///
+/// This layer can be used with a [`Registry`] to provide a tracing subscriber. The layer will
+/// spawn a separate thread to handle writing out chunks of an [`rfr`] chunked recording.
+///
+/// [`Registry`]: struct@tracing_subscriber::registry::Registry
+pub struct ChunkedLayer {
     writer_handle: WriterHandle,
     callsite_cache: Mutex<HashMap<CallsiteId, (Callsite, TraceKind)>>,
     object_cache: Mutex<HashMap<InstrumentationId, chunked::Object>>,
 }
 
-impl RfrChunkedLayer {
-    pub fn new(base_dir: &str) -> Self {
-        let writer_handle = Self::spawn_writer(base_dir.to_owned());
+impl ChunkedLayer {
+    /// Returns a [`ChunkedLayerBuilder`] which can be used to configure the chunked layer.
+    pub fn builder() -> ChunkedLayerBuilder {
+        Default::default()
+    }
 
-        Self {
+    /// Creates a new chunked layer with the given recording directory.
+    ///
+    /// This method may be deprecated in the future, instead [`builder`] should be used to
+    /// construct the chunked layer via the builder.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if the chunked writer could not be created or if the writer thread
+    /// could not be spawned.
+    pub fn new(base_dir: &str) -> Self {
+        let writer = ChunkedWriter::try_new(base_dir).expect("new writer failed");
+        Self::new_with_writer(writer).expect("spawn writer thread failed")
+    }
+
+    fn new_with_writer(writer: ChunkedWriter) -> Result<Self, io::Error> {
+        let writer_handle = Self::spawn_writer(writer)?;
+
+        Ok(Self {
             writer_handle,
             callsite_cache: Default::default(),
             object_cache: Default::default(),
-        }
+        })
     }
 
-    fn spawn_writer(base_dir: String) -> WriterHandle {
-        let writer = Arc::new(ChunkedWriter::try_new(base_dir).unwrap());
-
+    fn spawn_writer(writer: ChunkedWriter) -> Result<WriterHandle, io::Error> {
+        let writer = Arc::new(writer);
         let thread_writer = Arc::clone(&writer);
         let join_handle = thread::Builder::new()
             .name("rfr-writer".to_owned())
-            .spawn(move || run_writer_loop(thread_writer))
-            .unwrap();
+            .spawn(move || run_writer_loop(thread_writer))?;
 
-        WriterHandle {
+        Ok(WriterHandle {
             writer,
             join_handle: Mutex::new(Some(join_handle)),
-        }
+        })
     }
 
+    /// Returns the flusher for this layer.
+    ///
+    /// The [`Flusher`] can be used to wait for the last written traces to be written out to the
+    /// recording.
     pub fn flusher(&self) -> Flusher {
         Flusher {
             writer: Arc::clone(&self.writer_handle.writer),
         }
     }
+}
 
-    pub fn complete(&self) {
-        let join_handle = {
-            let mut guard = self.writer_handle.join_handle.lock().expect("poisoned");
-            guard.take()
-        };
-        if let Some(join_handle) = join_handle {
-            // TODO(hds): signal writer thread to stop
-            join_handle.join().unwrap();
-
-            self.writer_handle.writer.write_all_chunks();
-        } else {
-            // Otherwise some other thread has joined on the writer.
-        }
-    }
-
+/// Support methods for the Layer impl.
+impl ChunkedLayer {
     fn new_object(&self, iid: InstrumentationId, object: chunked::Object) {
         let mut object_cache = self.object_cache.lock().expect("object cache poisoned");
         object_cache.insert(iid, object);
@@ -152,11 +248,19 @@ fn run_writer_loop(writer: Arc<ChunkedWriter>) {
             // Error occurred, break.
             break;
         };
+        let sleep_until = time::Instant::now() + sleep_duration;
+        if let Err(err) = writer.clean_outdated_chunks() {
+            // TODO(hds): should we optionally log an error somehow?
+            _ = err;
+        }
+        // We recalculate the sleep duration here in case `clean_outdated_chunks` took some
+        // significant amount of time.
+        let sleep_duration = sleep_until.saturating_duration_since(time::Instant::now());
         thread::sleep(sleep_duration);
     }
 }
 
-impl<S> Layer<S> for RfrChunkedLayer
+impl<S> Layer<S> for ChunkedLayer
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {

--- a/rfr-subscriber/src/subscriber/mod.rs
+++ b/rfr-subscriber/src/subscriber/mod.rs
@@ -2,5 +2,7 @@ mod chunked;
 mod common;
 mod layer;
 
-pub use chunked::RfrChunkedLayer;
+pub use chunked::{
+    ChunkedLayer, ChunkedLayerBuildError, ChunkedLayerBuilder, FlushError, Flusher, StorageQuota,
+};
 pub use layer::RfrLayer;

--- a/rfr-subscriber/tests/chunked.rs
+++ b/rfr-subscriber/tests/chunked.rs
@@ -1,0 +1,98 @@
+use std::time::Duration;
+
+use tempfile::tempdir;
+use tracing_subscriber::{prelude::*, registry};
+
+use rfr::chunked;
+use rfr_subscriber::{ChunkedLayer, StorageQuota};
+
+#[test]
+fn record_spawn() {
+    let recording_dir = temp_recording_dir();
+    let layer = ChunkedLayer::builder()
+        .recording_dir(recording_dir.clone())
+        .build()
+        .unwrap();
+    let flusher = layer.flusher();
+    let subscriber = registry().with(layer);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async move {
+        tracing::subscriber::with_default(subscriber, move || {
+            tokio::task::Builder::new()
+                .name("the-task")
+                .spawn(async {})
+                .unwrap();
+            flusher.wait_flush().unwrap();
+        });
+    });
+
+    let mut recording = chunked::from_path(recording_dir).unwrap();
+    let chunks: Vec<_> = recording.chunks_lossy().flatten().collect();
+
+    let last_chunk = chunks.last().unwrap();
+    let objects: Vec<&chunked::Object> = last_chunk
+        .seq_chunks()
+        .iter()
+        .flat_map(|seq_chunk| &seq_chunk.objects)
+        .collect();
+
+    assert_eq!(objects.len(), 1);
+    match objects[0] {
+        chunked::Object::Task(task) => assert_eq!(task.task_name, "the-task".to_string()),
+        object => panic!("Expected object to be a Task, but instead got `{object:?}`"),
+    }
+}
+
+#[test]
+fn storage_quota() {
+    let recording_dir = temp_recording_dir();
+    let quota = StorageQuota {
+        max_chunks_hard: Some(2),
+        ..Default::default()
+    };
+    let layer = ChunkedLayer::builder()
+        .recording_dir(recording_dir.clone())
+        .storage_quota(quota)
+        .build()
+        .unwrap();
+    let flusher = layer.flusher();
+    let subscriber = registry().with(layer);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    tracing::subscriber::with_default(subscriber, move || {
+        rt.block_on(async move {
+            for _ in 0..5 {
+                tokio::task::Builder::new()
+                    .name("the-task")
+                    .spawn(async {})
+                    .unwrap();
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+            flusher.wait_flush().unwrap();
+        });
+    });
+
+    let mut recording = chunked::from_path(recording_dir).unwrap();
+    let chunks: Vec<_> = recording.chunks_lossy().flatten().collect();
+
+    assert_eq!(chunks.len(), 2);
+}
+
+fn temp_recording_dir() -> String {
+    tempdir()
+        .unwrap()
+        .path()
+        .join("recording.rfr")
+        .to_str()
+        .unwrap()
+        .to_owned()
+}


### PR DESCRIPTION
In #41, functionality was added to the `ChunkedWriter` to clean up older
chunks based on a storage quota. However, the tracing layer which writes
a chunked recorded didn't have this functionality exposed.

This change adds a builder for the `ChunkedLayer` (renamed from
`RfrChunkedLayer`) to allow the layer to be configured before it is
added to a registry.

The builder can be used to set the directory which will form the base of
the chunked recording, and also allows setting a `StorageQuota` which
will be set on the underlying `ChunkedWriter`.

Additionally, the chunked layer's writer loop (which runs in its own
thread) will now call `clean_outdated_chunks` on its writer after each
write.

The `rfr-subscriber` crate also finally got its first couple of
integration tests.