### PR TITLE
fix(rfr): improve chunked writer error handling

### DIFF
--- a/rfr-subscriber/src/subscriber/chunked.rs
+++ b/rfr-subscriber/src/subscriber/chunked.rs
@@ -20,6 +20,7 @@ use crate::subscriber::common::{
     get_context_task_iid, to_callsite, to_callsite_id, to_iid,
 };
 
+#[derive(Debug)]
 struct WriterHandle {
     writer: Arc<ChunkedWriter>,
     // TODO(hds): Is there actually ever a case where we need this? It feels wrong to throw away
@@ -144,6 +145,7 @@ impl error::Error for ChunkedLayerBuildError {}
 /// spawn a separate thread to handle writing out chunks of an [`rfr`] chunked recording.
 ///
 /// [`Registry`]: struct@tracing_subscriber::registry::Registry
+#[derive(Debug)]
 pub struct ChunkedLayer {
     writer_handle: WriterHandle,
     callsite_cache: Mutex<HashMap<CallsiteId, (Callsite, TraceKind)>>,
@@ -224,6 +226,7 @@ impl ChunkedLayer {
     }
 
     fn write_record(&self, timestamp: AbsTimestamp, data: chunked::RecordData) {
+        let mut append_result = Ok(());
         self.writer_handle
             .writer
             .with_seq_chunk_buffer(timestamp.clone(), |current_buffer| {
@@ -233,8 +236,15 @@ impl ChunkedLayer {
                     },
                     data,
                 };
-                current_buffer.append_record(record, |task_ids| self.get_objects(task_ids));
+                append_result =
+                    current_buffer.append_record(record, |task_ids| self.get_objects(task_ids));
             });
+
+        if let Err(err) = append_result {
+            // TODO(hds): Do something with this error? We don't want to fail, but maybe we can log
+            // it somehow
+            _ = err;
+        }
     }
 }
 

--- a/rfr-subscriber/src/subscriber/common.rs
+++ b/rfr-subscriber/src/subscriber/common.rs
@@ -8,13 +8,13 @@ use tracing::{
 };
 use tracing_subscriber::{layer::Context, registry::LookupSpan};
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(super) enum TraceKind {
     Span(SpanKind),
     Event(EventKind),
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(super) enum SpanKind {
     Spawn,
     Resource,
@@ -22,7 +22,7 @@ pub(super) enum SpanKind {
     AsyncOpPoll,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub(super) enum EventKind {
     Waker,
     PollOp,

--- a/rfr/src/chunked/mod.rs
+++ b/rfr/src/chunked/mod.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{AbsTimestamp, FormatIdentifier, FormatVariant, Span, Task};
@@ -171,6 +173,29 @@ pub struct ChunkInterval {
     base_time: AbsTimestampSecs,
     start_time: ChunkTimestamp,
     end_time: ChunkTimestamp,
+}
+
+impl fmt::Display for ChunkInterval {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let start_base = self.base_time.secs + self.start_time.micros / 1_000_000;
+        let start_micros = self.start_time.micros % 1_000_000;
+        let end_base = self.base_time.secs + self.end_time.micros / 1_000_000;
+        let end_micros = self.end_time.micros % 1_000_000;
+        write!(
+            f,
+            "({start_base}.{start_fraction} -> {end_base}.{end_fraction})",
+            start_fraction = if start_micros == 0 {
+                "0".to_string()
+            } else {
+                format!("{start_micros:06}")
+            },
+            end_fraction = if end_micros == 0 && start_micros == 0 {
+                "0".to_string()
+            } else {
+                format!("{end_micros:06}")
+            },
+        )
+    }
 }
 
 impl ChunkInterval {

--- a/rfr/src/chunked/sequence.rs
+++ b/rfr/src/chunked/sequence.rs
@@ -10,7 +10,7 @@
 use std::{
     cell::Cell,
     collections::{HashMap, HashSet},
-    io,
+    error, fmt, io,
     sync::{
         Mutex,
         atomic::{AtomicU64, Ordering},
@@ -155,19 +155,23 @@ impl SeqChunkBuffer {
     // FIXME(hds): modify to take an absolute timestamp and a record instead of a Record. Then this
     // function will convert the timestamp to a chunked timestamp and validate it at the same time.
     // If it is invalid, an error will be returned.
-    pub fn append_record<FnGetObjects>(&self, record: Record, get_objects: FnGetObjects)
+    pub fn append_record<FnGetObjects>(
+        &self,
+        record: Record,
+        get_objects: FnGetObjects,
+    ) -> Result<(), AppendRecordError>
     where
         FnGetObjects: FnOnce(&[InstrumentationId]) -> Vec<Option<Object>>,
     {
         let mut buffer = self.buffer.lock().expect("poisoned");
-        let mut missing_task_ids = Vec::new();
+        let mut missing_object_ids = Vec::new();
         match &record.data {
             RecordData::TaskNew { iid }
             | RecordData::TaskPollStart { iid }
             | RecordData::TaskPollEnd { iid }
             | RecordData::TaskDrop { iid } => {
                 if !buffer.objects.contains_key(iid) {
-                    missing_task_ids.push(*iid);
+                    missing_object_ids.push(*iid);
                 }
             }
             RecordData::WakerWake { waker }
@@ -175,13 +179,13 @@ impl SeqChunkBuffer {
             | RecordData::WakerClone { waker }
             | RecordData::WakerDrop { waker } => {
                 if !buffer.objects.contains_key(&waker.task_iid) {
-                    missing_task_ids.push(waker.task_iid);
+                    missing_object_ids.push(waker.task_iid);
                 }
                 if let Some(context_task_id) = &waker.context
                     && context_task_id != &waker.task_iid
                     && !buffer.objects.contains_key(context_task_id)
                 {
-                    missing_task_ids.push(*context_task_id);
+                    missing_object_ids.push(*context_task_id);
                 }
             }
             RecordData::SpanNew { iid }
@@ -198,20 +202,24 @@ impl SeqChunkBuffer {
         }
 
         // FIXME(hds): What if the 2 vecs are different sizes?
-        let missing_tasks = get_objects(missing_task_ids.as_slice());
-        for (task_id, task) in missing_task_ids.into_iter().zip(missing_tasks.into_iter()) {
-            match task {
-                Some(task) => {
-                    let task_buffer = postcard::to_stdvec(&task).unwrap();
-                    buffer.objects.insert(task_id, task_buffer);
+        let missing_objects = get_objects(missing_object_ids.as_slice());
+        for (iid, object) in missing_object_ids
+            .into_iter()
+            .zip(missing_objects.into_iter())
+        {
+            match object {
+                Some(object) => {
+                    let object_buffer =
+                        postcard::to_stdvec(&object).map_err(AppendRecordError::write_object)?;
+                    buffer.objects.insert(iid, object_buffer);
                 }
                 None => {
                     // TODO(hds): Currently we don't do anything with this information, should we?
                     //            Also, should we actually return early here or should we continue?
                     //            If we do want to return early, we should probably not write any
-                    //            task data to `buffer.objects`.
-                    buffer.missing_objects.insert(task_id);
-                    return;
+                    //            object data to `buffer.objects`.
+                    buffer.missing_objects.insert(iid);
+                    return Err(AppendRecordError::missing_object(iid));
                 }
             }
         }
@@ -220,22 +228,165 @@ impl SeqChunkBuffer {
             buffer.header.earliest_timestamp = record.meta.timestamp;
         }
         buffer.header.latest_timestamp = record.meta.timestamp;
-        postcard::to_io(&record, &mut buffer.records).unwrap();
+        postcard::to_io(&record, &mut buffer.records).map_err(AppendRecordError::write_record)?;
         buffer.record_count += 1;
+
+        Ok(())
     }
 
-    pub fn write(&self, writer: impl io::Write) {
+    pub fn write(&self, writer: impl io::Write) -> Result<(), SeqChunkWriteError> {
         let mut writer = writer;
-        let buffer = self.buffer.lock().expect("poisoned");
+        let buffer = self
+            .buffer
+            .lock()
+            .map_err(|_| SeqChunkWriteError::buffer_lock_poisoned())?;
 
-        postcard::to_io(&buffer.header, &mut writer).unwrap();
+        postcard::to_io(&buffer.header, &mut writer).map_err(SeqChunkWriteError::header)?;
 
-        postcard::to_io(&buffer.objects.len(), &mut writer).unwrap();
+        postcard::to_io(&buffer.objects.len(), &mut writer)
+            .map_err(SeqChunkWriteError::objects_length)?;
         for object_data in buffer.objects.values() {
-            writer.write_all(object_data.as_slice()).unwrap();
+            writer
+                .write_all(object_data.as_slice())
+                .map_err(SeqChunkWriteError::objects)?;
         }
 
-        postcard::to_io(&buffer.record_count, &mut writer).unwrap();
-        writer.write_all(buffer.records.as_slice()).unwrap();
+        postcard::to_io(&buffer.record_count, &mut writer)
+            .map_err(SeqChunkWriteError::records_length)?;
+        writer
+            .write_all(buffer.records.as_slice())
+            .map_err(SeqChunkWriteError::records)?;
+
+        Ok(())
     }
 }
+
+/// Error appending record to sequence chunk buffer
+#[derive(Debug)]
+pub struct AppendRecordError {
+    kind: AppendRecordErrorKind,
+}
+
+impl AppendRecordError {
+    fn missing_object(iid: InstrumentationId) -> Self {
+        Self {
+            kind: AppendRecordErrorKind::MissingObject { iid },
+        }
+    }
+
+    fn write_object(inner: postcard::Error) -> Self {
+        Self {
+            kind: AppendRecordErrorKind::WriteObject { inner },
+        }
+    }
+
+    fn write_record(inner: postcard::Error) -> Self {
+        Self {
+            kind: AppendRecordErrorKind::WriteRecord { inner },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum AppendRecordErrorKind {
+    MissingObject { iid: InstrumentationId },
+    WriteObject { inner: postcard::Error },
+    WriteRecord { inner: postcard::Error },
+}
+
+impl fmt::Display for AppendRecordError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, inner) = match &self.kind {
+            AppendRecordErrorKind::MissingObject { iid } => {
+                return write!(
+                    f,
+                    "failed to append record, could not get object for iid={}",
+                    iid.as_u64()
+                );
+            }
+            AppendRecordErrorKind::WriteObject { inner } => ("object", inner),
+            AppendRecordErrorKind::WriteRecord { inner } => ("record", inner),
+        };
+
+        write!(f, "failed to append record, write {kind} failed: {inner}")
+    }
+}
+
+impl error::Error for AppendRecordError {}
+
+/// Error writing contents of a [`SeqChunkBuffer`] to a writer.
+#[derive(Debug)]
+pub struct SeqChunkWriteError {
+    kind: SeqChunkWriteErrorKind,
+}
+
+impl SeqChunkWriteError {
+    fn buffer_lock_poisoned() -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::BufferLockPoisoned,
+        }
+    }
+
+    fn header(inner: postcard::Error) -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::Header { inner },
+        }
+    }
+
+    fn objects_length(inner: postcard::Error) -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::ObjectsLength { inner },
+        }
+    }
+
+    fn objects(inner: io::Error) -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::Objects { inner },
+        }
+    }
+
+    fn records_length(inner: postcard::Error) -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::RecordsLength { inner },
+        }
+    }
+
+    fn records(inner: io::Error) -> Self {
+        Self {
+            kind: SeqChunkWriteErrorKind::Records { inner },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum SeqChunkWriteErrorKind {
+    BufferLockPoisoned,
+    Header { inner: postcard::Error },
+    ObjectsLength { inner: postcard::Error },
+    Objects { inner: io::Error },
+    RecordsLength { inner: postcard::Error },
+    Records { inner: io::Error },
+}
+
+impl fmt::Display for SeqChunkWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, inner) = match &self.kind {
+            SeqChunkWriteErrorKind::BufferLockPoisoned => {
+                return write!(f, "sequence chunk buffer lock is poisoned");
+            }
+            SeqChunkWriteErrorKind::Header { inner } => ("header", inner as &dyn fmt::Display),
+            SeqChunkWriteErrorKind::ObjectsLength { inner } => {
+                ("objects length", inner as &dyn fmt::Display)
+            }
+            SeqChunkWriteErrorKind::Objects { inner } => ("objects", inner as &dyn fmt::Display),
+            SeqChunkWriteErrorKind::RecordsLength { inner } => {
+                ("records length", inner as &dyn fmt::Display)
+            }
+            SeqChunkWriteErrorKind::Records { inner } => ("records", inner as &dyn fmt::Display),
+        };
+
+        write!(f, "failed to write sequence chunk `{kind}`: {inner}")
+    }
+}
+
+impl error::Error for SeqChunkWriteError {}

--- a/rfr/src/chunked/write.rs
+++ b/rfr/src/chunked/write.rs
@@ -13,7 +13,8 @@ use std::{
 use jiff::{Timestamp, Zoned, tz::TimeZone};
 
 use crate::chunked::{
-    AbsTimestampSecs, ChunkedCallsitesWriter, ChunkedMeta, current_software_version,
+    AbsTimestampSecs, ChunkedCallsitesWriter, ChunkedMeta, SeqId, current_software_version,
+    sequence::SeqChunkWriteError,
 };
 use crate::{
     AbsTimestamp, Callsite,
@@ -159,17 +160,17 @@ impl ChunkedWriter {
         let meta = ChunkedMeta::new(vec![current_software_version()]);
 
         if let Ok(true) = root_dir.try_exists() {
-            return Err(NewChunkedWriterError::AlreadyExists);
+            return Err(NewChunkedWriterError::already_exists());
         }
 
-        fs::create_dir_all(root_dir).map_err(NewChunkedWriterError::CreateRecordingDirFailed)?;
+        fs::create_dir_all(root_dir).map_err(NewChunkedWriterError::create_recording_dir_failed)?;
         Self::write_meta(root_dir, &meta)?;
 
         let callsites_path = Path::new(&root_dir).join("callsites.rfr");
         let callsites_file = fs::File::create(callsites_path)
-            .map_err(|err| NewChunkedWriterError::WriteCallsitesFailed(WriteError::Io(err)))?;
+            .map_err(|err| NewChunkedWriterError::write_callsites_failed(WriteError::Io(err)))?;
         let callsites_writer = ChunkedCallsitesWriter::try_new(callsites_file)
-            .map_err(NewChunkedWriterError::WriteCallsitesFailed)?;
+            .map_err(NewChunkedWriterError::write_callsites_failed)?;
 
         // By default, chunks contain 1 second of execution time.
         let chunk_period_micros = 1_000_000;
@@ -185,7 +186,9 @@ impl ChunkedWriter {
         };
 
         let base_time = writer.base_time;
-        writer.ensure_dir(&base_time);
+        writer
+            .ensure_dir(&base_time)
+            .map_err(NewChunkedWriterError::create_recording_dir_failed)?;
 
         Ok(writer)
     }
@@ -225,14 +228,14 @@ impl ChunkedWriter {
         Ok(())
     }
 
-    fn ensure_dir(&self, time: &AbsTimestampSecs) {
-        fs::create_dir_all(self.dir_path(time)).unwrap();
+    fn ensure_dir(&self, time: &AbsTimestampSecs) -> Result<(), io::Error> {
+        fs::create_dir_all(self.dir_path(time)?)
     }
 
-    fn dir_path(&self, time: &AbsTimestampSecs) -> PathBuf {
-        let ts = Timestamp::from_second(time.secs as i64).unwrap();
+    fn dir_path(&self, time: &AbsTimestampSecs) -> Result<PathBuf, io::Error> {
+        let ts = Timestamp::from_second(time.secs as i64).map_err(io::Error::other)?;
         let ts_utc = ts.to_zoned(TimeZone::UTC);
-        self.dir_path_from_utc(&ts_utc)
+        Ok(self.dir_path_from_utc(&ts_utc))
     }
 
     fn dir_path_from_utc(&self, ts_utc: &Zoned) -> PathBuf {
@@ -241,13 +244,14 @@ impl ChunkedWriter {
             .join(format!("{}", ts_utc.strftime("%d-%H")))
     }
 
-    fn chunk_path(&self, chunk: &ChunkBuffer) -> PathBuf {
+    fn chunk_path(&self, chunk: &ChunkBuffer) -> Result<PathBuf, io::Error> {
         let time = &chunk.header.interval.base_time;
-        let ts = Timestamp::from_second(time.secs as i64).unwrap();
+        let ts = Timestamp::from_second(time.secs as i64).map_err(io::Error::other)?;
         let ts_utc = ts.to_zoned(TimeZone::UTC);
 
-        self.dir_path_from_utc(&ts_utc)
-            .join(format!("chunk-{}.rfr", ts_utc.strftime("%M-%S")))
+        Ok(self
+            .dir_path_from_utc(&ts_utc)
+            .join(format!("chunk-{}.rfr", ts_utc.strftime("%M-%S"))))
     }
 
     pub fn register_callsite(&self, callsite: Callsite) {
@@ -336,16 +340,25 @@ impl ChunkedWriter {
 
         let mut written_chunks: VecDeque<WrittenChunk> = VecDeque::new();
 
-        chunks.chunk_buffers.retain(|chunk_buffer| {
+        let mut idx = 0;
+        let write_result = loop {
+            let Some(chunk_buffer) = chunks.chunk_buffers.get(idx) else {
+                break Ok(());
+            };
+
             let end_time = chunk_buffer.header.interval.abs_end_time();
             let since_completion = AbsTimestamp::now()
                 .as_duration_since_epoch()
                 .saturating_sub(end_time.as_duration_since_epoch());
 
             if since_completion > write_time_buffer {
-                let mut writer = self.writer_for_chunk(chunk_buffer);
-                // TODO(hds): Check for errors
-                chunk_buffer.write(&mut writer);
+                let mut writer = match self.writer_for_chunk(chunk_buffer) {
+                    Ok(writer) => writer,
+                    Err(err) => break Err(err),
+                };
+                chunk_buffer
+                    .write(&mut writer)
+                    .map_err(|inner| WriteChunksError::write(chunk_buffer, inner))?;
                 written_chunks.push_front(writer.into());
 
                 self.notifiers
@@ -357,11 +370,11 @@ impl ChunkedWriter {
                     });
 
                 // TODO(hds): Perhaps retain the completed sequence chunks to avoid allocating again?
-                false
+                chunks.chunk_buffers.remove(idx);
             } else {
-                true
+                idx += 1;
             }
-        });
+        };
 
         // TODO(hds): We will end up in an inconsistent state if this thread panics between
         // removing chunk bufferes and adding written chunks. Ideally, we need to make sure that
@@ -372,6 +385,9 @@ impl ChunkedWriter {
         for written_chunk in written_chunks {
             chunks.written_chunks.push_front(written_chunk);
         }
+
+        // Once written chunks has been updated, we can safely return early if there was an error.
+        write_result?;
 
         // TODO(hds): Flush the callsites again afterwards to ensure consistency?
 
@@ -389,25 +405,25 @@ impl ChunkedWriter {
     /// The chunks are not discarded after being written. If further records are written to the
     /// contained sequence chunks, then they can be written to disk at a later time with subsequent
     /// calls to [`write_completed_chunks`] or [`write_all_chunks`].
-    pub fn write_all_chunks(&self) {
+    ///
+    /// Note that chunks written in this way aren't considered for the purposes of the storage
+    /// quota when calling [`cleanup_outdated_chunks`].
+    pub fn write_all_chunks(&self) -> Result<(), WriteChunksError> {
         // Flush the callsites first
         self.flush_callsites();
 
-        let mut chunks = self.chunks.lock().expect("poisoned");
-        let mut written_chunks: VecDeque<WrittenChunk> = VecDeque::new();
+        let chunks = self.chunks.lock().expect("poisoned");
 
-        chunks.chunk_buffers.iter().for_each(|chunk_buffer| {
-            let mut writer = self.writer_for_chunk(chunk_buffer);
-            chunk_buffer.write(&mut writer);
-            written_chunks.push_back(writer.into());
-        });
-
-        // TODO(hds): see note in `write_completed_chunks` regarding inconsistent states.
-        for written_chunk in written_chunks {
-            chunks.written_chunks.push_front(written_chunk);
+        for chunk_buffer in &chunks.chunk_buffers {
+            let mut writer = self.writer_for_chunk(chunk_buffer)?;
+            chunk_buffer
+                .write(&mut writer)
+                .map_err(|inner| WriteChunksError::write(chunk_buffer, inner))?;
         }
 
         // TODO(hds): Flush the callsites again afterwards to ensure consistency?
+
+        Ok(())
     }
 
     /// Wait for the current active chunk to be written to disk.
@@ -431,11 +447,23 @@ impl ChunkedWriter {
         }
     }
 
-    fn writer_for_chunk(&self, chunk: &ChunkBuffer) -> ChunkWriter {
-        let path = self.chunk_path(chunk);
-        let file = fs::File::create(&path).unwrap();
+    fn writer_for_chunk(&self, chunk: &ChunkBuffer) -> Result<ChunkWriter, WriteChunksError> {
+        let path = self
+            .chunk_path(chunk)
+            .map_err(|inner| WriteChunksError::chunk_path(chunk, inner))?;
+        let file = {
+            match fs::File::create(&path) {
+                Ok(file) => Ok(file),
+                Err(_err) => {
+                    self.ensure_dir(&chunk.header.interval.base_time)
+                        .map_err(|inner| WriteChunksError::chunk_dir(chunk, inner))?;
+                    fs::File::create(&path)
+                }
+            }
+            .map_err(|inner| WriteChunksError::file_open(chunk, inner))?
+        };
 
-        ChunkWriter { file, path, len: 0 }
+        Ok(ChunkWriter { file, path, len: 0 })
     }
 
     fn flush_callsites(&self) {
@@ -627,7 +655,38 @@ enum WaitForWrite {
 
 /// An error occuring when creating a new [`ChunkedWriter`].
 #[derive(Debug)]
-pub enum NewChunkedWriterError {
+pub struct NewChunkedWriterError {
+    kind: NewChunkedWriterErrorKind,
+}
+
+impl NewChunkedWriterError {
+    fn already_exists() -> Self {
+        Self {
+            kind: NewChunkedWriterErrorKind::AlreadyExists,
+        }
+    }
+
+    fn create_recording_dir_failed(inner: io::Error) -> Self {
+        Self {
+            kind: NewChunkedWriterErrorKind::CreateRecordingDirFailed(inner),
+        }
+    }
+
+    fn write_meta_failed(inner: WriteError) -> Self {
+        Self {
+            kind: NewChunkedWriterErrorKind::WriteMetaFailed(inner),
+        }
+    }
+
+    fn write_callsites_failed(inner: WriteError) -> Self {
+        Self {
+            kind: NewChunkedWriterErrorKind::WriteCallsitesFailed(inner),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum NewChunkedWriterErrorKind {
     /// There is already a chunked recording at this location
     AlreadyExists,
     /// Could not create the directory for the chunked recording
@@ -640,13 +699,17 @@ pub enum NewChunkedWriterError {
 
 impl fmt::Display for NewChunkedWriterError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::AlreadyExists => write!(f, "a chunked recording already exists at this location"),
-            Self::CreateRecordingDirFailed(inner) => {
+        match &self.kind {
+            NewChunkedWriterErrorKind::AlreadyExists => {
+                write!(f, "a chunked recording already exists at this location")
+            }
+            NewChunkedWriterErrorKind::CreateRecordingDirFailed(inner) => {
                 write!(f, "parent directory could not be created: {inner}")
             }
-            Self::WriteMetaFailed(inner) => write!(f, "failed to write `meta.rfr`: {inner}"),
-            Self::WriteCallsitesFailed(inner) => {
+            NewChunkedWriterErrorKind::WriteMetaFailed(inner) => {
+                write!(f, "failed to write `meta.rfr`: {inner}")
+            }
+            NewChunkedWriterErrorKind::WriteCallsitesFailed(inner) => {
                 write!(f, "failed to write `callsites.rfr` file: {inner}")
             }
         }
@@ -657,8 +720,8 @@ impl error::Error for NewChunkedWriterError {}
 impl From<NewMetaError> for NewChunkedWriterError {
     fn from(value: NewMetaError) -> Self {
         match value {
-            NewMetaError::AlreadyExists => NewChunkedWriterError::AlreadyExists,
-            NewMetaError::WriteFailed(inner) => NewChunkedWriterError::WriteMetaFailed(inner),
+            NewMetaError::AlreadyExists => NewChunkedWriterError::already_exists(),
+            NewMetaError::WriteFailed(inner) => NewChunkedWriterError::write_meta_failed(inner),
         }
     }
 }
@@ -708,11 +771,74 @@ impl fmt::Display for WriteError {
 
 impl error::Error for WriteError {}
 
-#[non_exhaustive]
+// Error writing chunks out to storage
 #[derive(Debug)]
-pub enum WriteChunksError {
-    FileOpenFailed,
+pub struct WriteChunksError {
+    chunk_interval: ChunkInterval,
+    kind: WriteChunksErrorKind,
 }
+
+impl WriteChunksError {
+    fn chunk_path(chunk: &ChunkBuffer, inner: io::Error) -> Self {
+        Self {
+            chunk_interval: chunk.header.interval.clone(),
+            kind: WriteChunksErrorKind::ChunkPath { inner },
+        }
+    }
+
+    fn chunk_dir(chunk: &ChunkBuffer, inner: io::Error) -> Self {
+        Self {
+            chunk_interval: chunk.header.interval.clone(),
+            kind: WriteChunksErrorKind::ChunkDir { inner },
+        }
+    }
+
+    fn file_open(chunk: &ChunkBuffer, inner: io::Error) -> Self {
+        Self {
+            chunk_interval: chunk.header.interval.clone(),
+            kind: WriteChunksErrorKind::FileOpen { inner },
+        }
+    }
+
+    fn write(chunk: &ChunkBuffer, inner: ChunkWriteError) -> Self {
+        Self {
+            chunk_interval: chunk.header.interval.clone(),
+            kind: WriteChunksErrorKind::Write { inner },
+        }
+    }
+}
+
+#[derive(Debug)]
+enum WriteChunksErrorKind {
+    ChunkPath { inner: io::Error },
+    ChunkDir { inner: io::Error },
+    FileOpen { inner: io::Error },
+    Write { inner: ChunkWriteError },
+}
+
+impl fmt::Display for WriteChunksError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let chunk_interval = &self.chunk_interval;
+        let (kind, inner) = match &self.kind {
+            WriteChunksErrorKind::ChunkPath { inner } => ("chunk path", inner),
+            WriteChunksErrorKind::ChunkDir { inner } => ("chunk dir", inner),
+            WriteChunksErrorKind::FileOpen { inner } => ("file open", inner),
+            WriteChunksErrorKind::Write { inner } => {
+                return write!(
+                    f,
+                    "failed to write serialized data to chunk `{chunk_interval}`: {inner}"
+                );
+            }
+        };
+
+        write!(
+            f,
+            "failed to write chunk `{chunk_interval}`, {kind}: {inner}"
+        )
+    }
+}
+
+impl error::Error for WriteChunksError {}
 
 #[non_exhaustive]
 #[derive(Debug)]
@@ -771,10 +897,11 @@ impl ChunkBuffer {
         seq_chunk_buffer
     }
 
-    fn write(&self, writer: impl io::Write) {
+    fn write(&self, writer: impl io::Write) -> Result<(), ChunkWriteError> {
         let mut writer = writer;
 
-        postcard::to_io(&current_software_version(), &mut writer).unwrap();
+        postcard::to_io(&current_software_version(), &mut writer)
+            .map_err(ChunkWriteError::identifier)?;
 
         let (earliest_timestamp, latest_timestamp) = self
             .seq_chunks
@@ -791,11 +918,86 @@ impl ChunkBuffer {
             earliest_timestamp,
             latest_timestamp,
         };
-        postcard::to_io(&header, &mut writer).unwrap();
+        postcard::to_io(&header, &mut writer).map_err(ChunkWriteError::header)?;
 
-        postcard::to_io(&self.seq_chunks.len(), &mut writer).unwrap();
+        postcard::to_io(&self.seq_chunks.len(), &mut writer)
+            .map_err(ChunkWriteError::seq_length)?;
         for seq_chunk in &self.seq_chunks {
-            seq_chunk.write(&mut writer);
+            seq_chunk
+                .write(&mut writer)
+                .map_err(|inner| ChunkWriteError::seq_chunk(seq_chunk.seq_id(), inner))?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Error writing a single chunk
+#[derive(Debug)]
+pub struct ChunkWriteError {
+    kind: ChunkWriteErrorKind,
+}
+
+impl ChunkWriteError {
+    fn identifier(inner: postcard::Error) -> Self {
+        Self {
+            kind: ChunkWriteErrorKind::Identifier { inner },
         }
     }
+
+    fn header(inner: postcard::Error) -> Self {
+        Self {
+            kind: ChunkWriteErrorKind::Header { inner },
+        }
+    }
+
+    fn seq_length(inner: postcard::Error) -> Self {
+        Self {
+            kind: ChunkWriteErrorKind::SeqLength { inner },
+        }
+    }
+
+    fn seq_chunk(seq_id: SeqId, inner: SeqChunkWriteError) -> Self {
+        Self {
+            kind: ChunkWriteErrorKind::SeqChunk { seq_id, inner },
+        }
+    }
+}
+
+impl fmt::Display for ChunkWriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let (kind, inner) = match &self.kind {
+            ChunkWriteErrorKind::SeqChunk { seq_id, inner } => {
+                return write!(
+                    f,
+                    "failed to write sequence chunk `{seq_id}`: {inner}",
+                    seq_id = seq_id.as_u64()
+                );
+            }
+            ChunkWriteErrorKind::Identifier { inner } => ("identifier", inner),
+            ChunkWriteErrorKind::Header { inner } => ("header", inner),
+            ChunkWriteErrorKind::SeqLength { inner } => ("sequence length", inner),
+        };
+
+        write!(f, "Failed to write chunk {kind}: {inner}")
+    }
+}
+
+impl error::Error for ChunkWriteError {}
+
+#[derive(Debug)]
+enum ChunkWriteErrorKind {
+    Identifier {
+        inner: postcard::Error,
+    },
+    Header {
+        inner: postcard::Error,
+    },
+    SeqLength {
+        inner: postcard::Error,
+    },
+    SeqChunk {
+        seq_id: SeqId,
+        inner: SeqChunkWriteError,
+    },
 }

--- a/rfr/tests/chunked_sequence.rs
+++ b/rfr/tests/chunked_sequence.rs
@@ -19,10 +19,12 @@ fn round_trip() {
         },
         data: RecordData::TaskNew { iid: task.iid },
     };
-    seq_chunk_buffer.append_record(record.clone(), |_task_ids| {
-        vec![Some(Object::Task(task.clone()))]
-    });
-    seq_chunk_buffer.write(&mut buffer);
+    seq_chunk_buffer
+        .append_record(record.clone(), |_task_ids| {
+            vec![Some(Object::Task(task.clone()))]
+        })
+        .unwrap();
+    seq_chunk_buffer.write(&mut buffer).unwrap();
 
     assert!(!buffer.is_empty());
 
@@ -58,7 +60,9 @@ fn skip_records_with_unknown_objects() {
             iid: InstrumentationId::from(5),
         },
     };
-    seq_chunk_buffer.append_record(record.clone(), |_task_ids| vec![None]);
+    seq_chunk_buffer
+        .append_record(record.clone(), |_task_ids| vec![None])
+        .unwrap_err();
 
     assert_eq!(seq_chunk_buffer.record_count(), 0);
 }
@@ -79,12 +83,14 @@ fn only_requests_object_once() {
         },
         data: RecordData::TaskNew { iid: task.iid },
     };
-    seq_chunk_buffer.append_record(record_1, |task_ids| {
-        assert_eq!(task_ids.len(), 1);
-        assert_eq!(task_ids[0], InstrumentationId::from(2));
+    seq_chunk_buffer
+        .append_record(record_1, |task_ids| {
+            assert_eq!(task_ids.len(), 1);
+            assert_eq!(task_ids[0], InstrumentationId::from(2));
 
-        vec![Some(Object::Task(task.clone()))]
-    });
+            vec![Some(Object::Task(task.clone()))]
+        })
+        .unwrap();
 
     let record_2 = Record {
         meta: Meta {
@@ -92,13 +98,15 @@ fn only_requests_object_once() {
         },
         data: RecordData::TaskDrop { iid: task.iid },
     };
-    seq_chunk_buffer.append_record(record_2, |task_ids| {
-        assert!(task_ids.is_empty());
+    seq_chunk_buffer
+        .append_record(record_2, |task_ids| {
+            assert!(task_ids.is_empty());
 
-        vec![]
-    });
+            vec![]
+        })
+        .unwrap();
 
-    seq_chunk_buffer.write(&mut buffer);
+    seq_chunk_buffer.write(&mut buffer).unwrap();
 }
 
 fn test_task(iid: u64) -> Task {

--- a/rfr/tests/chunked_writer.rs
+++ b/rfr/tests/chunked_writer.rs
@@ -3,10 +3,7 @@ use std::{fs, sync::Arc, thread, time::Duration};
 use rfr::{
     AbsTimestamp, Callsite, CallsiteId, Event, FieldName, FieldValue, InstrumentationId, Kind,
     Level, Parent,
-    chunked::{
-        self, ChunkedWriter, Meta, NewChunkedWriterError, Record, RecordData, StorageQuota,
-        from_path,
-    },
+    chunked::{self, ChunkedWriter, Meta, Record, RecordData, StorageQuota, from_path},
 };
 use tempfile::tempdir;
 
@@ -26,10 +23,9 @@ fn spawn_writer_loop(writer: Arc<ChunkedWriter>) {
                     break;
                 }
 
-                let Ok(sleep_duration) = writer.write_completed_chunks() else {
-                    // Error occurred, break.
-                    break;
-                };
+                let sleep_duration = writer
+                    .write_completed_chunks()
+                    .expect("Writing completed chunks failed");
                 thread::sleep(sleep_duration);
             }
         })
@@ -75,7 +71,7 @@ fn record_single_event() {
             },
         };
 
-        buffer.append_record(record, no_objects);
+        buffer.append_record(record, no_objects).unwrap();
     });
 
     writer
@@ -118,12 +114,7 @@ fn directory_already_exists() {
         "expected `ChunkedWriter::try_new` to return an error"
     );
 
-    match result.unwrap_err() {
-        NewChunkedWriterError::AlreadyExists => {} // expected result
-        other_err => panic!(
-            "expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"
-        ),
-    }
+    result.unwrap_err();
 }
 
 #[test]
@@ -140,12 +131,7 @@ fn meta_already_exists() {
         "expected `ChunkedWriter::try_new` to return an error"
     );
 
-    match result.unwrap_err() {
-        NewChunkedWriterError::AlreadyExists => {} // expected result
-        other_err => panic!(
-            "expected error `NewChunkedWriterError::AlreadyExists`, but instead got `{other_err:?}`"
-        ),
-    }
+    result.unwrap_err();
 }
 
 fn write_event_chunk_loop(writer: &ChunkedWriter, repeats: u64) {
@@ -183,7 +169,7 @@ fn write_event_chunk_loop(writer: &ChunkedWriter, repeats: u64) {
                 },
             };
 
-            buffer.append_record(record, no_objects);
+            buffer.append_record(record, no_objects).unwrap();
         });
 
         let sleep_duration = writer.write_completed_chunks().unwrap();


### PR DESCRIPTION
Many parts of the chunked recording writing were unwrapping results,
which could result in a panic causing the entire writer thread to panic
(which would then cause application threads to panic when attempting to
lock the now poisoned chunk lock when recording traces).

This change adds better error handling for most of the chunked recording
writer methods. Returning `Result` from those APIs instead of panicking.